### PR TITLE
feat: optimize push pipeline and stabilize retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - `target_sessions`：会话列表（UMO）
 - `send_pdf`：是否附 PDF，默认 `false`
 - `pdf_dpi`：转图 DPI，默认 `170`
-- `send_concurrency`：并发推送会话数，默认 `3`
+- `send_concurrency`：并发推送会话数，默认 `3`（建议 `1-5`，最大 `20`）
 - `supabase_url`：Supabase API 地址
 - `supabase_publishable_key`：Supabase Publishable Key（已内置默认值，可覆盖；也可用环境变量 `SUPABASE_PUBLISHABLE_KEY`）
 - `command_admin_only`：仅管理员可用命令，默认 `true`

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -46,7 +46,7 @@
     "description": "并发推送会话数",
     "type": "int",
     "default": 3,
-    "hint": "同时向多少个目标会话发送消息，值越大越快"
+    "hint": "同时向多少个目标会话发送消息，建议 1-5"
   },
   "temp_keep_files": {
     "description": "临时文件最多保留数量",

--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ DEFAULT_SUPABASE_URL = "https://bcgdqepzakcufaadgnda.supabase.co"
 DEFAULT_SUPABASE_BUCKET = "manuscripts"
 DEFAULT_ZONE = "septic"
 DEFAULT_SCHEDULE_TIMES = ["09:00", "21:00"]
+MAX_SEND_CONCURRENCY = 20
 SUPABASE_KEY_ENV_NAME = "SUPABASE_PUBLISHABLE_KEY"
 DISCIPLINE_LABELS: dict[str, tuple[str, str]] = {
     "interdisciplinary": ("交叉", "Interdisciplinary"),
@@ -68,7 +69,12 @@ class ShitJournalDailyPlugin(Star):
         self._plugin_data_dir = self._resolve_plugin_data_dir()
         self._temp_dir = self._plugin_data_dir / "tmp"
         self._ensure_supabase_key_or_raise()
-        self._send_concurrency = self._cfg_int("send_concurrency", 3, min_value=1)
+        self._send_concurrency = self._cfg_int(
+            "send_concurrency",
+            3,
+            min_value=1,
+            max_value=MAX_SEND_CONCURRENCY,
+        )
         self._temp_dir.mkdir(parents=True, exist_ok=True)
         await self._clear_cron_jobs()
         await self._register_cron_jobs()
@@ -475,7 +481,12 @@ class ShitJournalDailyPlugin(Star):
         png_file: Path,
         pdf_file: Path,
     ) -> tuple[int, list[str]]:
-        concurrency = max(1, int(getattr(self, "_send_concurrency", 3)))
+        raw_concurrency = getattr(self, "_send_concurrency", 3)
+        try:
+            configured_concurrency = int(raw_concurrency)
+        except (TypeError, ValueError):
+            configured_concurrency = 3
+        concurrency = min(MAX_SEND_CONCURRENCY, max(1, configured_concurrency))
         semaphore = asyncio.Semaphore(concurrency)
 
         async def _send_one(session: str) -> tuple[str, bool]:
@@ -489,8 +500,21 @@ class ShitJournalDailyPlugin(Star):
             logger.info("send message result: session=%s success=%s", session, ok)
             return session, ok
 
-        results = await asyncio.gather(*[_send_one(session) for session in targets])
-        success_targets = [session for session, ok in results if ok]
+        results = await asyncio.gather(
+            *[_send_one(session) for session in targets],
+            return_exceptions=True,
+        )
+        ok_results: list[tuple[str, bool]] = []
+        for result in results:
+            if isinstance(result, BaseException):
+                logger.error(
+                    "unexpected send task error",
+                    exc_info=(type(result), result, result.__traceback__),
+                )
+                continue
+            ok_results.append(result)
+
+        success_targets = [session for session, ok in ok_results if ok]
         sent_ok = len(success_targets)
         return sent_ok, success_targets
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_shitjournal_daily
 display_name: shitjournal_daily
 desc: 每日定时抓取并推送 shitjournal 最新论文
-version: v1.0.2
+version: v1.0.3
 author: qiyi71w
 repo: https://github.com/qiyi71w/astrbot_plugin_shitjournal_daily


### PR DESCRIPTION
## Summary by Sourcery

优化推送投递性能，并增强计划任务 shitjournal 每日推送流程中的网络与冷却（cooldown）处理的健壮性。

New Features:
- 为向多个会话进行推送投递新增可配置的发送并发度。
- 为出站 HTTP 请求引入基于线程的可复用 HTTP 会话，并启用连接池。

Bug Fixes:
- 使用单调时间来跟踪分组冷却时间，避免系统时钟变更带来的问题。
- 确保在命令执行和计划任务运行结束时，即使发生失败，也能在 finally 块中清理并截断临时文件。
- 稳定 HTTP 重试行为，引入有上界的指数退避并复用共享会话，以减少不稳定的失败。

Enhancements:
- 将整数配置解析逻辑集中处理，并在超时、重试、DPI、冷却时间和临时文件保留时长等配置上统一验证和限幅。
- 汇报部分成功的推送结果，仅对成功通知到的目标更新投递追踪信息。
- 在插件终止时清理所有 HTTP 会话，避免资源泄漏。

Documentation:
- 在 README 中记录新的 `send_concurrency` 配置选项，并提升插件版本号。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize push delivery performance and harden network and cooldown handling for the scheduled shitjournal daily push flow.

New Features:
- Add configurable send concurrency for push deliveries to multiple sessions.
- Introduce per-thread reusable HTTP sessions with connection pooling for outbound requests.

Bug Fixes:
- Use monotonic time for group cooldown tracking to avoid issues from system clock changes.
- Ensure temporary files are trimmed in finally blocks after commands and scheduled runs, even on failures.
- Stabilize HTTP retry behavior with bounded exponential backoff and shared session reuse to reduce flaky failures.

Enhancements:
- Centralize integer configuration parsing with validation and clamping across timeouts, retries, DPI, cooldowns, and temp file retention.
- Report partial push outcomes and update delivery tracking only for successfully notified targets.
- Clean up all HTTP sessions on plugin termination to avoid resource leaks.

Documentation:
- Document the new send_concurrency configuration option in the README and bump the plugin version.

</details>