### PR TITLE
refactor: 拆分 shitjournal_daily 插件职责并完成主流程瘦身

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # astrbot_plugin_shitjournal_daily
 
+## SHIT期刊似乎死了？
+
 每日定时抓取 `shitjournal` 最新论文并推送到会话：
 - 推送文本元信息
 - 推送 PDF 第 1 页预览图

--- a/main.py
+++ b/main.py
@@ -14,15 +14,35 @@ from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, filter
 from astrbot.api.star import Context, Star, StarTools, register
 
-try:
-    from .services import PdfService, PushMessageService, SupabaseClient, TempFileManager
+if __package__:
+    from .services import (
+        PdfService,
+        PushMessageService,
+        RunBatch,
+        RunBatchReport,
+        RunReason,
+        RunReport,
+        RunStatus,
+        SupabaseClient,
+        TempFileManager,
+    )
     from .services.session_message import is_private_message_session
     from .services.sensitive import mask_sensitive_text
-except ImportError:
+else:
     _plugin_dir = Path(__file__).resolve().parent
     if str(_plugin_dir) not in sys.path:
         sys.path.insert(0, str(_plugin_dir))
-    from services import PdfService, PushMessageService, SupabaseClient, TempFileManager
+    from services import (
+        PdfService,
+        PushMessageService,
+        RunBatch,
+        RunBatchReport,
+        RunReason,
+        RunReport,
+        RunStatus,
+        SupabaseClient,
+        TempFileManager,
+    )
     from services.session_message import is_private_message_session
     from services.sensitive import mask_sensitive_text
 
@@ -587,35 +607,27 @@ class ShitJournalDailyPlugin(Star):
         force: bool,
         source: str,
         latest_only: bool = False,
-    ) -> dict[str, Any]:
+    ) -> RunReport:
         if self._run_lock.locked():
-            return {
-                "status": "skipped",
-                "reason_code": "RUN_IN_PROGRESS",
-                "source": source,
-                "debug_reason": "",
-                "latest_only": latest_only,
-            }
+            return RunReport(
+                status=RunStatus.SKIPPED,
+                reason_code=RunReason.RUN_IN_PROGRESS,
+                source=source,
+                debug_reason="",
+                latest_only=latest_only,
+            )
 
         async with self._run_lock:
             primary_zone = self._get_primary_zone()
             zone_order = self._get_candidate_zones(primary_zone)
-            report: dict[str, Any] = {
-                "status": "failed",
-                "source": source,
-                "zone": primary_zone,
-                "requested_zone": primary_zone,
-                "force": force,
-                "paper_id": "",
-                "detail_url": "",
-                "sent_ok": 0,
-                "sent_total": 0,
-                "reason_code": "",
-                "debug_reason": "",
-                "latest_only": latest_only,
-                "batches": [],
-                "warnings": [],
-            }
+            report = RunReport(
+                status=RunStatus.FAILED,
+                source=source,
+                zone=primary_zone,
+                requested_zone=primary_zone,
+                force=force,
+                latest_only=latest_only,
+            )
             logger.info(
                 "开始执行推送：来源=%s 主分区=%s 分区顺序=%s 强制=%s 仅最新=%s",
                 source,
@@ -627,7 +639,7 @@ class ShitJournalDailyPlugin(Star):
             try:
                 targets = await self._get_all_target_sessions()
                 if not targets:
-                    report["reason_code"] = "NO_TARGET_SESSION_CONFIGURED"
+                    report.reason_code = RunReason.NO_TARGET_SESSION_CONFIGURED
                     return report
 
                 last_seen_map = await self._get_last_seen_map()
@@ -641,13 +653,13 @@ class ShitJournalDailyPlugin(Star):
                     )
                 except RunSelectionError as exc:
                     message = str(exc).strip()
-                    report["reason_code"] = exc.reason_code
+                    report.reason_code = self._coerce_run_reason(exc.reason_code)
                     logger.error(
                         "获取最新论文失败：%s",
                         mask_sensitive_text(message),
                         exc_info=True,
                     )
-                    report["debug_reason"] = mask_sensitive_text(message)
+                    report.debug_reason = mask_sensitive_text(message)
                     return report
                 except RuntimeError as exc:
                     message = str(exc).strip()
@@ -656,48 +668,51 @@ class ShitJournalDailyPlugin(Star):
                         mask_sensitive_text(message),
                         exc_info=True,
                     )
-                    report["reason_code"] = "FETCH_LATEST_FAILED"
-                    report["debug_reason"] = mask_sensitive_text(message)
+                    report.reason_code = RunReason.FETCH_LATEST_FAILED
+                    report.debug_reason = mask_sensitive_text(message)
                     return report
-                report["warnings"] = selection_warnings
+                report.warnings = selection_warnings
 
                 if not batches:
                     if selection_warnings:
-                        report["status"] = "failed"
-                        report["reason_code"] = "FETCH_LATEST_FAILED"
-                        report["debug_reason"] = self._join_warning_text(selection_warnings)
+                        report.status = RunStatus.FAILED
+                        report.reason_code = RunReason.FETCH_LATEST_FAILED
+                        report.debug_reason = self._join_warning_text(selection_warnings)
                         if last_seen_dirty:
                             await self.put_kv_data("last_seen_by_zone", last_seen_map)
                         return report
-                    report["status"] = "skipped"
-                    report["reason_code"] = "ALREADY_DELIVERED" if saw_submission else "LATEST_NOT_FOUND"
+                    report.status = RunStatus.SKIPPED
+                    report.reason_code = (
+                        RunReason.ALREADY_DELIVERED if saw_submission else RunReason.LATEST_NOT_FOUND
+                    )
                     if last_seen_dirty:
                         await self.put_kv_data("last_seen_by_zone", last_seen_map)
                     return report
 
-                batch_reports = await self._send_run_batches(
+                raw_batch_reports = await self._send_run_batches(
                     batches,
                     send_semaphore=asyncio.Semaphore(self._get_configured_send_concurrency()),
                 )
-                report["batches"] = batch_reports
-                report["sent_ok"] = sum(int(batch.get("sent_ok", 0)) for batch in batch_reports)
-                report["sent_total"] = sum(int(batch.get("sent_total", 0)) for batch in batch_reports)
+                batch_reports = [self._coerce_run_batch_report(item) for item in raw_batch_reports]
+                report.batches = batch_reports
+                report.sent_ok = sum(batch.sent_ok for batch in batch_reports)
+                report.sent_total = sum(batch.sent_total for batch in batch_reports)
                 if batch_reports:
                     first_batch = batch_reports[0]
-                    report["zone"] = str(first_batch.get("zone", primary_zone))
-                    report["paper_id"] = str(first_batch.get("paper_id", ""))
-                    report["detail_url"] = str(first_batch.get("detail_url", ""))
+                    report.zone = first_batch.zone or primary_zone
+                    report.paper_id = first_batch.paper_id
+                    report.detail_url = first_batch.detail_url
                 first_debug_reason = self._pick_first_batch_debug_reason(batch_reports)
                 if first_debug_reason:
-                    report["debug_reason"] = first_debug_reason
+                    report.debug_reason = first_debug_reason
 
                 if last_seen_dirty:
                     await self.put_kv_data("last_seen_by_zone", last_seen_map)
 
-                report["status"], report["reason_code"] = self._resolve_run_batch_reports(
+                report.status, report.reason_code = self._resolve_run_batch_reports(
                     batch_reports=batch_reports,
-                    sent_ok=report["sent_ok"],
-                    sent_total=report["sent_total"],
+                    sent_ok=report.sent_ok,
+                    sent_total=report.sent_total,
                 )
                 return report
             finally:
@@ -764,7 +779,7 @@ class ShitJournalDailyPlugin(Star):
         last_seen_map: dict[str, str],
         force: bool,
         latest_only: bool,
-    ) -> tuple[list[dict[str, Any]], bool, bool, list[str]]:
+    ) -> tuple[list[RunBatch], bool, bool, list[str]]:
         if latest_only:
             return await self._select_latest_only_run_batches(
                 zone_order=zone_order,
@@ -776,7 +791,7 @@ class ShitJournalDailyPlugin(Star):
         saw_submission = False
         last_seen_dirty = False
         unresolved_targets = targets.copy()
-        batches: list[dict[str, Any]] = []
+        batches: list[RunBatch] = []
         warnings: list[str] = []
         for index, zone in enumerate(zone_order):
             if not unresolved_targets:
@@ -813,11 +828,11 @@ class ShitJournalDailyPlugin(Star):
         targets: list[str],
         last_seen_map: dict[str, str],
         force: bool,
-    ) -> tuple[list[dict[str, Any]], bool, bool, list[str]]:
+    ) -> tuple[list[RunBatch], bool, bool, list[str]]:
         saw_submission = False
         last_seen_dirty = False
         unresolved_targets = targets.copy()
-        batches: list[dict[str, Any]] = []
+        batches: list[RunBatch] = []
         warnings: list[str] = []
         for index, zone in enumerate(zone_order):
             if not unresolved_targets:
@@ -856,12 +871,12 @@ class ShitJournalDailyPlugin(Star):
         last_seen_map: dict[str, str],
         force: bool,
         first_page_candidates: list[dict[str, Any]] | None,
-    ) -> tuple[list[dict[str, Any]], set[str], bool, bool, list[str]]:
+    ) -> tuple[list[RunBatch], set[str], bool, bool, list[str]]:
         if not first_page_candidates:
             return [], set(), False, False, []
         sent_history_by_target = await self._get_run_sent_histories(zone, unresolved_targets)
         sent_history_lookup_by_target = self._build_history_lookup(sent_history_by_target)
-        batches: list[dict[str, Any]] = []
+        batches: list[RunBatch] = []
         matched_targets: set[str] = set()
         saw_submission = False
         last_seen_dirty = False
@@ -913,7 +928,7 @@ class ShitJournalDailyPlugin(Star):
         last_seen_map: dict[str, str],
         force: bool,
         first_page_candidates: list[dict[str, Any]] | None,
-    ) -> tuple[dict[str, Any] | None, set[str], bool, bool]:
+    ) -> tuple[RunBatch | None, set[str], bool, bool]:
         candidates = first_page_candidates
         if not candidates:
             return None, set(), False, False
@@ -980,8 +995,8 @@ class ShitJournalDailyPlugin(Star):
         is_primary: bool,
         zone_latest_recorded: bool,
         last_seen_map: dict[str, str],
-    ) -> tuple[list[dict[str, Any]], bool, bool, bool, set[str]]:
-        page_batches: list[dict[str, Any]] = []
+    ) -> tuple[list[RunBatch], bool, bool, bool, set[str]]:
+        page_batches: list[RunBatch] = []
         page_targets: set[str] = set()
         occupied_targets = set(matched_targets)
         last_seen_dirty = False
@@ -1071,16 +1086,16 @@ class ShitJournalDailyPlugin(Star):
         targets: list[str],
         sent_history_by_target: dict[str, list[str]],
         sent_history_lookup_by_target: dict[str, set[str]],
-    ) -> dict[str, Any]:
-        return {
-            "zone": zone,
-            "latest": candidate,
-            "paper_id": paper_id,
-            "detail_url": self._build_preprint_detail_url(paper_id),
-            "targets": targets,
-            "sent_history_by_target": sent_history_by_target,
-            "sent_history_lookup_by_target": sent_history_lookup_by_target,
-        }
+    ) -> RunBatch:
+        return RunBatch(
+            zone=zone,
+            latest=candidate,
+            paper_id=paper_id,
+            detail_url=self._build_preprint_detail_url(paper_id),
+            targets=targets,
+            sent_history_by_target=sent_history_by_target,
+            sent_history_lookup_by_target=sent_history_lookup_by_target,
+        )
 
     async def _fetch_run_candidates_page(
         self,
@@ -1179,15 +1194,15 @@ class ShitJournalDailyPlugin(Star):
 
     async def _send_run_batches(
         self,
-        batches: list[dict[str, Any]],
+        batches: list[RunBatch],
         *,
         send_semaphore: asyncio.Semaphore | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> list[RunBatchReport | dict[str, Any]]:
         if not batches:
             return []
         semaphore = asyncio.Semaphore(self._resolve_batch_send_concurrency(len(batches)))
 
-        async def _send_one(batch: dict[str, Any]) -> dict[str, Any]:
+        async def _send_one(batch: RunBatch) -> RunBatchReport:
             async with semaphore:
                 if send_semaphore is None:
                     return await self._send_run_batch(batch)
@@ -1197,17 +1212,17 @@ class ShitJournalDailyPlugin(Star):
 
     async def _send_run_batch(
         self,
-        batch: dict[str, Any],
+        batch: RunBatch,
         *,
         send_semaphore: asyncio.Semaphore | None = None,
-    ) -> dict[str, Any]:
-        zone = str(batch["zone"])
-        latest = dict(batch["latest"])
-        paper_id = str(batch["paper_id"])
-        detail_url = str(batch["detail_url"])
-        targets = list(batch["targets"])
-        sent_history_by_target = dict(batch["sent_history_by_target"])
-        sent_history_lookup_by_target = dict(batch["sent_history_lookup_by_target"])
+    ) -> RunBatchReport:
+        zone = str(batch.zone)
+        latest = dict(batch.latest)
+        paper_id = str(batch.paper_id)
+        detail_url = str(batch.detail_url)
+        targets = list(batch.targets)
+        sent_history_by_target = dict(batch.sent_history_by_target)
+        sent_history_lookup_by_target = dict(batch.sent_history_lookup_by_target)
         report = self._build_run_batch_report(
             zone=zone,
             paper_id=paper_id,
@@ -1236,7 +1251,7 @@ class ShitJournalDailyPlugin(Star):
                 pdf_url=pdf_url,
                 send_semaphore=send_semaphore,
             )
-            report["sent_ok"] = sent_ok
+            report.sent_ok = sent_ok
             if sent_success_targets:
                 await self._mark_targets_delivered(
                     zone=zone,
@@ -1245,11 +1260,11 @@ class ShitJournalDailyPlugin(Star):
                     sent_history_by_target=sent_history_by_target,
                     sent_history_lookup_by_target=sent_history_lookup_by_target,
                 )
-            report["status"] = self._resolve_send_status(sent_ok=sent_ok, sent_total=len(targets))
-            report["reason_code"] = self._resolve_send_reason_code(str(report["status"]))
+            report.status = self._resolve_send_status(sent_ok=sent_ok, sent_total=len(targets))
+            report.reason_code = self._resolve_send_reason_code(report.status)
             return report
         except Exception as exc:
-            if report["sent_ok"] > 0:
+            if report.sent_ok > 0:
                 logger.error(
                     "写入推送去重状态失败：分区=%s 论文ID=%s 错误=%s",
                     zone,
@@ -1259,7 +1274,7 @@ class ShitJournalDailyPlugin(Star):
                 )
                 return self._build_failed_run_batch_report(
                     report=report,
-                    reason_code="DELIVERY_STATE_WRITE_FAILED",
+                    reason_code=RunReason.DELIVERY_STATE_WRITE_FAILED,
                     debug_reason=str(exc),
                 )
             logger.error(
@@ -1271,7 +1286,7 @@ class ShitJournalDailyPlugin(Star):
             )
             return self._build_failed_run_batch_report(
                 report=report,
-                reason_code="ALL_SENDS_FAILED",
+                reason_code=RunReason.ALL_SENDS_FAILED,
                 debug_reason=str(exc),
             )
         finally:
@@ -1288,55 +1303,84 @@ class ShitJournalDailyPlugin(Star):
         paper_id: str,
         detail_url: str,
         sent_total: int,
-    ) -> dict[str, Any]:
-        return {
-            "status": "failed",
-            "reason_code": "",
-            "zone": zone,
-            "paper_id": paper_id,
-            "detail_url": detail_url,
-            "sent_ok": 0,
-            "sent_total": sent_total,
-            "debug_reason": "",
-        }
+    ) -> RunBatchReport:
+        return RunBatchReport(
+            status=RunStatus.FAILED,
+            reason_code=RunReason.UNKNOWN,
+            zone=zone,
+            paper_id=paper_id,
+            detail_url=detail_url,
+            sent_ok=0,
+            sent_total=sent_total,
+            debug_reason="",
+        )
 
     def _build_failed_run_batch_report(
         self,
         *,
-        report: dict[str, Any],
-        reason_code: str,
+        report: RunBatchReport,
+        reason_code: RunReason | str,
         debug_reason: str,
-    ) -> dict[str, Any]:
-        report["status"] = "failed"
-        report["reason_code"] = reason_code
-        report["debug_reason"] = mask_sensitive_text(debug_reason)
+    ) -> RunBatchReport:
+        report.status = RunStatus.FAILED
+        report.reason_code = self._coerce_run_reason(reason_code)
+        report.debug_reason = mask_sensitive_text(debug_reason)
         return report
 
-    def _resolve_send_status(self, *, sent_ok: int, sent_total: int) -> str:
+    def _resolve_send_status(self, *, sent_ok: int, sent_total: int) -> RunStatus:
         if sent_total > 0 and sent_ok == sent_total:
-            return "success"
+            return RunStatus.SUCCESS
         if sent_ok > 0:
-            return "partial"
-        return "failed"
+            return RunStatus.PARTIAL
+        return RunStatus.FAILED
 
     def _resolve_run_batch_reports(
         self,
         *,
-        batch_reports: list[dict[str, Any]],
+        batch_reports: list[RunBatchReport],
         sent_ok: int,
         sent_total: int,
-    ) -> tuple[str, str]:
-        if any(str(batch.get("reason_code", "")) == "DELIVERY_STATE_WRITE_FAILED" for batch in batch_reports):
-            return "failed", "DELIVERY_STATE_WRITE_FAILED"
+    ) -> tuple[RunStatus, RunReason]:
+        if any(batch.reason_code == RunReason.DELIVERY_STATE_WRITE_FAILED for batch in batch_reports):
+            return RunStatus.FAILED, RunReason.DELIVERY_STATE_WRITE_FAILED
         status = self._resolve_send_status(sent_ok=sent_ok, sent_total=sent_total)
         return status, self._resolve_send_reason_code(status)
 
-    def _resolve_send_reason_code(self, status: str) -> str:
-        if status == "success":
-            return "PUSHED_SUCCESSFULLY"
-        if status == "partial":
-            return "PUSHED_PARTIALLY"
-        return "ALL_SENDS_FAILED"
+    def _resolve_send_reason_code(self, status: RunStatus | str) -> RunReason:
+        normalized = self._coerce_run_status(status)
+        if normalized == RunStatus.SUCCESS:
+            return RunReason.PUSHED_SUCCESSFULLY
+        if normalized == RunStatus.PARTIAL:
+            return RunReason.PUSHED_PARTIALLY
+        return RunReason.ALL_SENDS_FAILED
+
+    def _coerce_run_status(self, value: RunStatus | str) -> RunStatus:
+        if isinstance(value, RunStatus):
+            return value
+        text = str(value).strip().lower()
+        try:
+            return RunStatus(text)
+        except ValueError:
+            return RunStatus.UNKNOWN
+
+    def _coerce_run_reason(self, value: RunReason | str) -> RunReason:
+        if isinstance(value, RunReason):
+            return value
+        text = str(value).strip()
+        try:
+            return RunReason(text)
+        except ValueError:
+            return RunReason.UNKNOWN
+
+    def _coerce_run_batch_report(self, value: RunBatchReport | dict[str, Any]) -> RunBatchReport:
+        if isinstance(value, RunBatchReport):
+            return value
+        return RunBatchReport.from_dict(value)
+
+    def _to_run_report_dict(self, report: RunReport | dict[str, Any]) -> dict[str, Any]:
+        if isinstance(report, RunReport):
+            return report.to_dict()
+        return dict(report)
 
     def _resolve_batch_send_concurrency(self, batch_count: int) -> int:
         return min(MAX_BATCH_SEND_CONCURRENCY, self._get_configured_send_concurrency(), batch_count)
@@ -1355,9 +1399,9 @@ class ShitJournalDailyPlugin(Star):
     def _render_reason_text(self, reason_code: str) -> str:
         return REPORT_REASON_LABELS.get(reason_code, reason_code)
 
-    def _pick_first_batch_debug_reason(self, batch_reports: list[dict[str, Any]]) -> str:
+    def _pick_first_batch_debug_reason(self, batch_reports: list[RunBatchReport]) -> str:
         for batch_report in batch_reports:
-            debug_reason = mask_sensitive_text(str(batch_report.get("debug_reason", "")).strip())
+            debug_reason = mask_sensitive_text(str(batch_report.debug_reason).strip())
             if debug_reason:
                 return debug_reason
         return ""
@@ -2333,19 +2377,20 @@ class ShitJournalDailyPlugin(Star):
             include_debug=include_debug,
         )
 
-    def _render_report(self, report: dict[str, Any], include_debug: bool = False) -> str:
-        status = str(report.get("status", "unknown") or "unknown")
-        reason_code = str(report.get("reason_code") or report.get("reason") or "UNKNOWN")
-        debug_reason = mask_sensitive_text(str(report.get("debug_reason", "")).strip())
-        latest_only = self._to_bool(report.get("latest_only"), False)
-        requested_zone = str(report.get("requested_zone", "")).strip()
-        warnings = self._clean_warning_list(report.get("warnings", []))
+    def _render_report(self, report: RunReport | dict[str, Any], include_debug: bool = False) -> str:
+        report_dict = self._to_run_report_dict(report)
+        status = str(report_dict.get("status", "unknown") or "unknown")
+        reason_code = str(report_dict.get("reason_code") or report_dict.get("reason") or "UNKNOWN")
+        debug_reason = mask_sensitive_text(str(report_dict.get("debug_reason", "")).strip())
+        latest_only = self._to_bool(report_dict.get("latest_only"), False)
+        requested_zone = str(report_dict.get("requested_zone", "")).strip()
+        warnings = self._clean_warning_list(report_dict.get("warnings", []))
         status_text = self._render_status_text(status)
         reason_text = self._render_reason_text(reason_code)
-        batches = list(report.get("batches", []))
+        batches = list(report_dict.get("batches", []))
         if len(batches) > 1:
             return self._render_multi_batch_report(
-                report=report,
+                report=report_dict,
                 status_text=status_text,
                 reason_text=reason_text,
                 latest_only=latest_only,
@@ -2356,7 +2401,7 @@ class ShitJournalDailyPlugin(Star):
             )
         if len(batches) == 1:
             return self._render_single_batch_report(
-                report=report,
+                report=report_dict,
                 batch=batches[0],
                 status_text=status_text,
                 reason_text=reason_text,
@@ -2367,15 +2412,15 @@ class ShitJournalDailyPlugin(Star):
                 include_debug=include_debug,
             )
         empty_batch = {
-            "status": str(report.get("status", "unknown") or "unknown"),
-            "zone": str(report.get("zone", "")).strip(),
-            "paper_id": str(report.get("paper_id", "")).strip(),
-            "detail_url": str(report.get("detail_url", "")).strip(),
-            "sent_ok": report.get("sent_ok", 0),
-            "sent_total": report.get("sent_total", 0),
+            "status": str(report_dict.get("status", "unknown") or "unknown"),
+            "zone": str(report_dict.get("zone", "")).strip(),
+            "paper_id": str(report_dict.get("paper_id", "")).strip(),
+            "detail_url": str(report_dict.get("detail_url", "")).strip(),
+            "sent_ok": report_dict.get("sent_ok", 0),
+            "sent_total": report_dict.get("sent_total", 0),
         }
         return self._render_single_batch_report(
-            report=report,
+            report=report_dict,
             batch=empty_batch,
             status_text=status_text,
             reason_text=reason_text,

--- a/main.py
+++ b/main.py
@@ -24,7 +24,6 @@ if __package__:
         ReportRenderer,
         RunBatchSender,
         RunCycleService,
-        RunReport,
         RunSelector,
         SupabaseClient,
         TempFileManager,
@@ -46,7 +45,6 @@ else:
         ReportRenderer,
         RunBatchSender,
         RunCycleService,
-        RunReport,
         RunSelector,
         SupabaseClient,
         TempFileManager,
@@ -210,9 +208,12 @@ class ShitJournalDailyPlugin(Star):
             context_getter=lambda: self.context,
             cfg_int_getter=self._cfg_int,
             history_store=self._history_store,
-            load_submission_payload=self._load_submission_payload,
-            prepare_pdf_assets=self._prepare_pdf_assets,
-            build_push_text=lambda payload, detail_url, zone: self._build_push_text(
+            load_submission_payload=lambda latest, paper_id: self._asset_pipeline.load_submission_payload(
+                latest,
+                paper_id,
+            ),
+            prepare_pdf_assets=lambda payload, paper_id: self._asset_pipeline.prepare_pdf_assets(payload, paper_id),
+            build_push_text=lambda payload, detail_url, zone: self._asset_pipeline.build_push_text(
                 payload,
                 detail_url,
                 zone=zone,
@@ -220,7 +221,7 @@ class ShitJournalDailyPlugin(Star):
             build_meta_preview=lambda payload: self._asset_pipeline.build_meta_preview(payload),
             send_session_push=lambda **kwargs: self._push_messages.send_session_push(**kwargs),
             release_temp_files=lambda pdf_file, png_file: self._temp_files.release(pdf_file, png_file),
-            maybe_trim_temp_files=self._maybe_trim_temp_files,
+            maybe_trim_temp_files=lambda: self._maybe_trim_temp_files(),
             logger=logger,
             mask_sensitive_text=mask_sensitive_text,
             max_send_concurrency=MAX_SEND_CONCURRENCY,
@@ -232,7 +233,7 @@ class ShitJournalDailyPlugin(Star):
             cfg_getter=self._cfg,
             run_selector=self._run_selector,
             history_store=self._history_store,
-            send_batches=lambda batches, send_semaphore=None: self._send_run_batches(
+            send_batches=lambda batches, send_semaphore=None: self._run_batch_sender.send_run_batches(
                 batches,
                 send_semaphore=send_semaphore,
             ),
@@ -245,7 +246,7 @@ class ShitJournalDailyPlugin(Star):
             get_primary_zone=self._get_primary_zone,
             get_candidate_zones=self._get_candidate_zones,
             get_configured_send_concurrency=self._get_configured_send_concurrency,
-            maybe_trim_temp_files=self._maybe_trim_temp_files,
+            maybe_trim_temp_files=lambda: self._maybe_trim_temp_files(),
             logger=logger,
             mask_sensitive_text=mask_sensitive_text,
             run_fetch_page_size=RUN_FETCH_PAGE_SIZE,
@@ -261,10 +262,7 @@ class ShitJournalDailyPlugin(Star):
             kv_putter=self.put_kv_data,
             get_cron_job_ids=lambda: list(self._cron_job_ids),
             set_cron_job_ids=self._set_cron_job_ids,
-            scheduled_handler=lambda schedule_time="": self._cron_scheduler.scheduled_tick(
-                schedule_time=schedule_time,
-            ),
-            run_cycle=lambda **kwargs: self._run_cycle(**kwargs),
+            run_cycle=lambda **kwargs: self._run_cycle_service.run_cycle(**kwargs),
             render_report=lambda report, include_debug=False: self._report_renderer.render_report(
                 report,
                 include_debug=include_debug,
@@ -278,16 +276,23 @@ class ShitJournalDailyPlugin(Star):
             select_candidate_from_zones=lambda **kwargs: self._run_selector.select_chi_shi_candidate_from_zones(
                 **kwargs,
             ),
-            load_submission_payload=self._load_submission_payload,
-            prepare_pdf_assets=self._prepare_pdf_assets,
-            build_push_text=lambda payload, detail_url, zone: self._build_push_text(
+            load_submission_payload=lambda candidate, paper_id: self._asset_pipeline.load_submission_payload(
+                candidate,
+                paper_id,
+            ),
+            prepare_pdf_assets=lambda payload, paper_id: self._asset_pipeline.prepare_pdf_assets(payload, paper_id),
+            build_push_text=lambda payload, detail_url, zone: self._asset_pipeline.build_push_text(
                 payload,
                 detail_url,
                 zone=zone,
             ),
-            build_preprint_detail_url=self._build_preprint_detail_url,
+            build_preprint_detail_url=lambda paper_id: self._asset_pipeline.build_preprint_detail_url(paper_id),
             send_event_push=lambda **kwargs: self._push_messages.send_event_push(**kwargs),
-            mark_chi_shi_paper_sent=self._mark_chi_shi_paper_sent,
+            mark_chi_shi_paper_sent=lambda zone, session_key, paper_id: self._history_store.mark_chi_shi_paper_sent(
+                zone,
+                session_key,
+                paper_id,
+            ),
             get_primary_zone=self._get_primary_zone,
             get_candidate_zones=self._get_candidate_zones,
             build_zone_scope_text=self._build_zone_scope_text,
@@ -390,7 +395,7 @@ class ShitJournalDailyPlugin(Star):
 
         if action == "run":
             force = bool(arg) and arg.split()[0] == "force"
-            report = await self._run_cycle(force=force, source=f"手动:{event.get_sender_id()}")
+            report = await self._run_cycle_service.run_cycle(force=force, source=f"手动:{event.get_sender_id()}")
             yield event.plain_result(self._report_renderer.render_report(report))
             return
 
@@ -465,19 +470,6 @@ class ShitJournalDailyPlugin(Star):
         for output in outputs:
             yield event.plain_result(output)
 
-    def __getattr__(self, name: str) -> Any:
-        compatibility_map = {
-            "_register_cron_jobs": lambda: self._cron_scheduler.register_cron_jobs,
-            "_clear_cron_jobs": lambda: self._cron_scheduler.clear_cron_jobs,
-            "_parse_command_action_arg": lambda: self._command_gate.parse_command_action_arg,
-            "_build_chi_shi_failure_text": lambda: self._chi_shi_service.build_chi_shi_failure_text,
-            "_send_run_batches": lambda: self._run_batch_sender.send_run_batches,
-        }
-        getter = compatibility_map.get(name)
-        if getter is None:
-            raise AttributeError(name)
-        return getter()
-
     def _get_chi_shi_session_scope_text(self, event: AstrMessageEvent) -> str:
         if event.get_group_id():
             return "本群"
@@ -489,19 +481,6 @@ class ShitJournalDailyPlugin(Star):
     def _set_cron_job_ids(self, ids: list[str]) -> None:
         self._cron_job_ids = [str(job_id).strip() for job_id in ids if str(job_id).strip()]
 
-    async def _run_cycle(
-        self,
-        *,
-        force: bool,
-        source: str,
-        latest_only: bool = False,
-    ) -> RunReport:
-        return await self._run_cycle_service.run_cycle(
-            force=force,
-            source=source,
-            latest_only=latest_only,
-        )
-
     def _get_configured_send_concurrency(self) -> int:
         raw_concurrency = getattr(self, "_send_concurrency", 3)
         try:
@@ -509,30 +488,6 @@ class ShitJournalDailyPlugin(Star):
         except (TypeError, ValueError):
             configured_concurrency = 3
         return min(MAX_SEND_CONCURRENCY, max(1, configured_concurrency))
-
-    async def _load_submission_payload(
-        self,
-        latest: dict[str, Any],
-        paper_id: str,
-    ) -> dict[str, Any]:
-        return await self._asset_pipeline.load_submission_payload(latest, paper_id)
-
-    async def _prepare_pdf_assets(self, payload: dict[str, Any], paper_id: str) -> tuple[Path, Path, str]:
-        return await self._asset_pipeline.prepare_pdf_assets(payload, paper_id)
-
-    async def _mark_chi_shi_paper_sent(self, zone: str, session_key: str, paper_id: str) -> None:
-        await self._history_store.mark_chi_shi_paper_sent(zone, session_key, paper_id)
-
-    def _build_push_text(
-        self,
-        payload: dict[str, Any],
-        detail_url: str,
-        zone: str = "",
-    ) -> str:
-        return self._asset_pipeline.build_push_text(payload, detail_url, zone=zone)
-
-    def _build_preprint_detail_url(self, paper_id: str) -> str:
-        return self._asset_pipeline.build_preprint_detail_url(paper_id)
 
     def _resolve_plugin_data_dir(self) -> Path:
         plugin_name = str(

--- a/main.py
+++ b/main.py
@@ -22,16 +22,10 @@ if __package__:
         PdfService,
         PushMessageService,
         ReportRenderer,
-        RunBatch,
-        RunBatchReport,
         RunBatchSender,
         RunCycleService,
-        RunReason,
         RunReport,
-        RunSelectionResult,
-        RunSelectionError,
         RunSelector,
-        RunStatus,
         SupabaseClient,
         TempFileManager,
     )
@@ -50,16 +44,10 @@ else:
         PdfService,
         PushMessageService,
         ReportRenderer,
-        RunBatch,
-        RunBatchReport,
         RunBatchSender,
         RunCycleService,
-        RunReason,
         RunReport,
-        RunSelectionResult,
-        RunSelectionError,
         RunSelector,
-        RunStatus,
         SupabaseClient,
         TempFileManager,
     )
@@ -273,7 +261,9 @@ class ShitJournalDailyPlugin(Star):
             kv_putter=self.put_kv_data,
             get_cron_job_ids=lambda: list(self._cron_job_ids),
             set_cron_job_ids=self._set_cron_job_ids,
-            scheduled_handler=self._scheduled_tick,
+            scheduled_handler=lambda schedule_time="": self._cron_scheduler.scheduled_tick(
+                schedule_time=schedule_time,
+            ),
             run_cycle=lambda **kwargs: self._run_cycle(**kwargs),
             render_report=lambda report, include_debug=False: self._report_renderer.render_report(
                 report,
@@ -319,13 +309,13 @@ class ShitJournalDailyPlugin(Star):
         )
         self._temp_dir.mkdir(parents=True, exist_ok=True)
         await self._history_store.ensure_chi_shi_history_storage_ready()
-        await self._clear_cron_jobs()
-        await self._register_cron_jobs()
+        await self._cron_scheduler.clear_cron_jobs()
+        await self._cron_scheduler.register_cron_jobs()
         await self._maybe_trim_temp_files(force=True)
         logger.info("shitjournal_daily 插件初始化完成。")
 
     async def terminate(self):
-        await self._clear_cron_jobs()
+        await self._cron_scheduler.clear_cron_jobs()
         await self._supabase.close()
         logger.info("shitjournal_daily 插件已停止。")
 
@@ -337,7 +327,7 @@ class ShitJournalDailyPlugin(Star):
         **kwargs: Any,
     ):
         """管理 shitjournal 每日推送：bind/unbind/targets/run/run force"""
-        normalized = self._normalize_command_event(
+        normalized = self._command_gate.normalize_command_event(
             event=event,
             args=args,
             kwargs=kwargs,
@@ -347,15 +337,15 @@ class ShitJournalDailyPlugin(Star):
             return
         event, args, kwargs = normalized
 
-        if not await self._check_command_permission(event):
+        if not await self._command_gate.check_command_permission(event):
             return
 
-        action, arg = self._parse_command_action_arg(
+        action, arg = self._command_gate.parse_command_action_arg(
             args=args,
             kwargs=kwargs,
             default_action="help",
         )
-        fallback_action, fallback_arg = self._parse_action_arg_from_message(
+        fallback_action, fallback_arg = self._command_gate.parse_action_arg_from_message(
             event=event,
             command_name="shitjournal",
         )
@@ -423,7 +413,7 @@ class ShitJournalDailyPlugin(Star):
     ):
         """抓取最新论文并推送到当前会话（按会话冷却）"""
         # 兼容 AstrBot 不同注入路径下的命令参数形态。
-        normalized = self._normalize_command_event(
+        normalized = self._command_gate.normalize_command_event(
             event=event,
             args=args,
             kwargs=kwargs,
@@ -434,8 +424,8 @@ class ShitJournalDailyPlugin(Star):
         event, _, _ = normalized
         scope_label = self._get_chi_shi_session_scope_text(event)
         session_key = event.unified_msg_origin
-        ignore_cooldown = self._is_admin_event(event)
-        allowed, deny_reason = await self._try_enter_chi_shi_cooldown(
+        ignore_cooldown = self._command_gate.is_admin_event(event)
+        allowed, deny_reason = await self._chi_shi_service.try_enter_chi_shi_cooldown(
             session_key=session_key,
             scope_label=scope_label,
             ignore_cooldown=ignore_cooldown,
@@ -449,7 +439,7 @@ class ShitJournalDailyPlugin(Star):
         pdf_file: Path | None = None
         png_file: Path | None = None
         try:
-            outputs, apply_success_cooldown, pdf_file, png_file = await self._execute_wo_yao_chi_shi(
+            outputs, apply_success_cooldown, pdf_file, png_file = await self._chi_shi_service.execute_wo_yao_chi_shi(
                 event=event,
                 session_key=session_key,
                 scope_label=scope_label,
@@ -462,7 +452,7 @@ class ShitJournalDailyPlugin(Star):
             )
             outputs = ["抓取失败，请稍后重试。"]
         finally:
-            await self._leave_chi_shi_cooldown(
+            await self._chi_shi_service.leave_chi_shi_cooldown(
                 session_key=session_key,
                 apply_success_cooldown=apply_success_cooldown,
                 ignore_cooldown=ignore_cooldown,
@@ -475,73 +465,18 @@ class ShitJournalDailyPlugin(Star):
         for output in outputs:
             yield event.plain_result(output)
 
-    async def _execute_wo_yao_chi_shi(
-        self,
-        *,
-        event: AstrMessageEvent,
-        session_key: str,
-        scope_label: str,
-    ) -> tuple[list[str], bool, Path | None, Path | None]:
-        return await self._chi_shi_service.execute_wo_yao_chi_shi(
-            event=event,
-            session_key=session_key,
-            scope_label=scope_label,
-        )
-
-    def _build_missing_chi_shi_selection_response(
-        self,
-        *,
-        zone_order: list[str],
-        scope_label: str,
-        saw_candidates: bool,
-        selection_warnings: list[str],
-    ) -> tuple[bool, str]:
-        return self._chi_shi_service.build_missing_chi_shi_selection_response(
-            zone_order=zone_order,
-            scope_label=scope_label,
-            saw_candidates=saw_candidates,
-            selection_warnings=selection_warnings,
-        )
-
-    async def _push_chi_shi_selection(
-        self,
-        *,
-        event: AstrMessageEvent,
-        session_key: str,
-        selection: Any,
-    ) -> tuple[bool, Path | None, Path | None]:
-        return await self._chi_shi_service.push_chi_shi_selection(
-            event=event,
-            session_key=session_key,
-            selection=selection,
-        )
-
-    async def _check_command_permission(self, event: AstrMessageEvent) -> bool:
-        return await self._command_gate.check_command_permission(event)
-
-    # 命令兼容层：处理 AstrBot 在不同注入路径下 event/action 参数位置不一致的情况。
-    def _normalize_command_event(
-        self,
-        event: Any,
-        args: tuple[Any, ...],
-        kwargs: dict[str, Any],
-        command_name: str,
-    ) -> tuple[AstrMessageEvent, tuple[Any, ...], dict[str, Any]] | None:
-        return self._command_gate.normalize_command_event(
-            event=event,
-            args=args,
-            kwargs=kwargs,
-            command_name=command_name,
-        )
-
-    def _looks_like_message_event(self, value: Any) -> bool:
-        return self._command_gate.looks_like_message_event(value)
-
-    def _is_admin_event(self, event: AstrMessageEvent) -> bool:
-        return self._command_gate.is_admin_event(event)
-
-    def _is_sender_in_admins(self, event: AstrMessageEvent) -> bool:
-        return self._command_gate.is_sender_in_admins(event)
+    def __getattr__(self, name: str) -> Any:
+        compatibility_map = {
+            "_register_cron_jobs": lambda: self._cron_scheduler.register_cron_jobs,
+            "_clear_cron_jobs": lambda: self._cron_scheduler.clear_cron_jobs,
+            "_parse_command_action_arg": lambda: self._command_gate.parse_command_action_arg,
+            "_build_chi_shi_failure_text": lambda: self._chi_shi_service.build_chi_shi_failure_text,
+            "_send_run_batches": lambda: self._run_batch_sender.send_run_batches,
+        }
+        getter = compatibility_map.get(name)
+        if getter is None:
+            raise AttributeError(name)
+        return getter()
 
     def _get_chi_shi_session_scope_text(self, event: AstrMessageEvent) -> str:
         if event.get_group_id():
@@ -551,50 +486,8 @@ class ShitJournalDailyPlugin(Star):
             return "当前私聊"
         return "当前会话"
 
-    async def _try_enter_chi_shi_cooldown(
-        self,
-        session_key: str,
-        scope_label: str,
-        ignore_cooldown: bool,
-    ) -> tuple[bool, str]:
-        return await self._chi_shi_service.try_enter_chi_shi_cooldown(
-            session_key=session_key,
-            scope_label=scope_label,
-            ignore_cooldown=ignore_cooldown,
-        )
-
-    async def _leave_chi_shi_cooldown(
-        self,
-        session_key: str,
-        apply_success_cooldown: bool,
-        ignore_cooldown: bool,
-    ) -> None:
-        await self._chi_shi_service.leave_chi_shi_cooldown(
-            session_key=session_key,
-            apply_success_cooldown=apply_success_cooldown,
-            ignore_cooldown=ignore_cooldown,
-        )
-
-    async def _register_cron_jobs(self) -> None:
-        await self._cron_scheduler.register_cron_jobs()
-
-    async def _clear_cron_jobs(self) -> None:
-        await self._cron_scheduler.clear_cron_jobs()
-
-    async def _load_cron_job_ids(self) -> list[str]:
-        return await self._cron_scheduler.load_cron_job_ids()
-
-    async def _delete_cron_jobs(self, cron_manager: Any, ids: list[str]) -> list[str]:
-        return await self._cron_scheduler.delete_cron_jobs(cron_manager, ids)
-
-    def _resolve_schedule_times(self) -> list[str]:
-        return self._cron_scheduler.resolve_schedule_times()
-
     def _set_cron_job_ids(self, ids: list[str]) -> None:
         self._cron_job_ids = [str(job_id).strip() for job_id in ids if str(job_id).strip()]
-
-    async def _scheduled_tick(self, schedule_time: str = "") -> None:
-        await self._cron_scheduler.scheduled_tick(schedule_time=schedule_time)
 
     async def _run_cycle(
         self,
@@ -609,260 +502,6 @@ class ShitJournalDailyPlugin(Star):
             latest_only=latest_only,
         )
 
-    async def _run_cycle_locked(
-        self,
-        *,
-        force: bool,
-        source: str,
-        latest_only: bool,
-    ) -> RunReport:
-        return await self._run_cycle_service.run_cycle(
-            force=force,
-            source=source,
-            latest_only=latest_only,
-        )
-
-    def _build_run_in_progress_report(self, *, source: str, latest_only: bool) -> RunReport:
-        return self._run_cycle_service._build_run_in_progress_report(
-            source=source,
-            latest_only=latest_only,
-        )
-
-    def _build_run_cycle_report(
-        self,
-        *,
-        source: str,
-        primary_zone: str,
-        force: bool,
-        latest_only: bool,
-    ) -> RunReport:
-        return self._run_cycle_service._build_run_cycle_report(
-            source=source,
-            primary_zone=primary_zone,
-            force=force,
-            latest_only=latest_only,
-        )
-
-    async def _select_run_cycle_batches(
-        self,
-        *,
-        report: RunReport,
-        zone_order: list[str],
-        targets: list[str],
-        force: bool,
-        latest_only: bool,
-    ) -> tuple[dict[str, str], RunSelectionResult | None]:
-        return await self._run_cycle_service._select_run_cycle_batches(
-            report=report,
-            zone_order=zone_order,
-            targets=targets,
-            force=force,
-            latest_only=latest_only,
-        )
-
-    def _apply_run_selection_error(
-        self,
-        *,
-        report: RunReport,
-        reason_code: RunReason,
-        message: str,
-    ) -> None:
-        self._run_cycle_service._apply_run_selection_error(report, reason_code, message)
-
-    async def _finalize_empty_run_selection(
-        self,
-        *,
-        report: RunReport,
-        selection: RunSelectionResult,
-        previous_last_seen: dict[str, str],
-    ) -> RunReport:
-        return await self._run_cycle_service._finalize_empty_run_selection(
-            report=report,
-            selection=selection,
-            previous_last_seen=previous_last_seen,
-        )
-
-    async def _deliver_selected_run_batches(
-        self,
-        *,
-        batches: list[RunBatch],
-    ) -> list[RunBatchReport]:
-        return await self._run_cycle_service._deliver_selected_run_batches(batches)
-
-    def _apply_run_batch_reports_to_report(
-        self,
-        *,
-        report: RunReport,
-        batch_reports: list[RunBatchReport],
-        primary_zone: str,
-    ) -> None:
-        self._run_cycle_service._apply_run_batch_reports_to_report(
-            report,
-            batch_reports,
-            primary_zone,
-        )
-
-    async def _persist_last_seen_map_if_changed(
-        self,
-        *,
-        previous_last_seen: dict[str, str],
-        next_last_seen_map: dict[str, str],
-    ) -> None:
-        await self._run_cycle_service._persist_last_seen_map_if_changed(
-            previous_last_seen,
-            next_last_seen_map,
-        )
-
-    async def _send_run_batches(
-        self,
-        batches: list[RunBatch],
-        *,
-        send_semaphore: asyncio.Semaphore | None = None,
-    ) -> list[RunBatchReport | dict[str, Any]]:
-        return await self._run_batch_sender.send_run_batches(
-            batches,
-            send_semaphore=send_semaphore,
-        )
-
-    async def _send_run_batch(
-        self,
-        batch: RunBatch,
-        *,
-        send_semaphore: asyncio.Semaphore | None = None,
-    ) -> RunBatchReport:
-        return await self._run_batch_sender.send_run_batch(
-            batch,
-            send_semaphore=send_semaphore,
-        )
-
-    async def _send_run_batch_inner(
-        self,
-        *,
-        batch: RunBatch,
-        send_semaphore: asyncio.Semaphore | None,
-    ) -> RunBatchReport:
-        return await self._run_batch_sender.send_run_batch_inner(
-            batch=batch,
-            send_semaphore=send_semaphore,
-        )
-
-    def _unpack_run_batch(
-        self,
-        batch: RunBatch,
-    ) -> tuple[str, dict[str, Any], str, str, list[str]]:
-        return (
-            str(batch.zone),
-            dict(batch.latest),
-            str(batch.paper_id),
-            str(batch.detail_url),
-            list(batch.targets),
-        )
-
-    async def _prepare_run_batch_delivery(
-        self,
-        *,
-        latest: dict[str, Any],
-        paper_id: str,
-        detail_url: str,
-        zone: str,
-    ) -> tuple[dict[str, Any], Path | None, Path | None, str, str]:
-        return await self._run_batch_sender.prepare_run_batch_delivery(
-            latest=latest,
-            paper_id=paper_id,
-            detail_url=detail_url,
-            zone=zone,
-        )
-
-    async def _persist_run_batch_success_targets(
-        self,
-        *,
-        zone: str,
-        paper_id: str,
-        success_targets: list[str],
-    ) -> None:
-        await self._run_batch_sender.persist_run_batch_success_targets(
-            zone=zone,
-            paper_id=paper_id,
-            success_targets=success_targets,
-        )
-
-    def _build_run_batch_exception_report(
-        self,
-        *,
-        report: RunBatchReport,
-        zone: str,
-        paper_id: str,
-        error: Exception,
-    ) -> RunBatchReport:
-        return self._run_batch_sender.build_run_batch_exception_report(
-            report=report,
-            zone=zone,
-            paper_id=paper_id,
-            error=error,
-        )
-
-    def _build_run_batch_report(
-        self,
-        *,
-        zone: str,
-        paper_id: str,
-        detail_url: str,
-        sent_total: int,
-    ) -> RunBatchReport:
-        return self._run_batch_sender.build_run_batch_report(
-            zone=zone,
-            paper_id=paper_id,
-            detail_url=detail_url,
-            sent_total=sent_total,
-        )
-
-    def _build_failed_run_batch_report(
-        self,
-        *,
-        report: RunBatchReport,
-        reason_code: RunReason | str,
-        debug_reason: str,
-    ) -> RunBatchReport:
-        return self._run_batch_sender.build_failed_run_batch_report(
-            report=report,
-            reason_code=reason_code,
-            debug_reason=debug_reason,
-        )
-
-    def _resolve_send_status(self, *, sent_ok: int, sent_total: int) -> RunStatus:
-        return self._run_batch_sender.resolve_send_status(
-            sent_ok=sent_ok,
-            sent_total=sent_total,
-        )
-
-    def _resolve_run_batch_reports(
-        self,
-        *,
-        batch_reports: list[RunBatchReport],
-        sent_ok: int,
-        sent_total: int,
-    ) -> tuple[RunStatus, RunReason]:
-        return self._run_batch_sender.resolve_run_batch_reports(
-            batch_reports=batch_reports,
-            sent_ok=sent_ok,
-            sent_total=sent_total,
-        )
-
-    def _resolve_send_reason_code(self, status: RunStatus | str) -> RunReason:
-        return self._run_batch_sender.resolve_send_reason_code(status)
-
-    def _coerce_run_status(self, value: RunStatus | str) -> RunStatus:
-        return self._run_batch_sender.coerce_run_status(value)
-
-    def _coerce_run_reason(self, value: RunReason | str) -> RunReason:
-        return self._run_batch_sender.coerce_run_reason(value)
-
-    def _coerce_run_batch_report(self, value: RunBatchReport | dict[str, Any]) -> RunBatchReport:
-        return self._run_batch_sender.coerce_run_batch_report(value)
-
-    def _resolve_batch_send_concurrency(self, batch_count: int) -> int:
-        return self._run_batch_sender.resolve_batch_send_concurrency(batch_count)
-
     def _get_configured_send_concurrency(self) -> int:
         raw_concurrency = getattr(self, "_send_concurrency", 3)
         try:
@@ -870,9 +509,6 @@ class ShitJournalDailyPlugin(Star):
         except (TypeError, ValueError):
             configured_concurrency = 3
         return min(MAX_SEND_CONCURRENCY, max(1, configured_concurrency))
-
-    def _pick_first_batch_debug_reason(self, batch_reports: list[RunBatchReport]) -> str:
-        return self._run_cycle_service._pick_first_debug_reason(batch_reports)
 
     async def _load_submission_payload(
         self,
@@ -886,25 +522,6 @@ class ShitJournalDailyPlugin(Star):
 
     async def _mark_chi_shi_paper_sent(self, zone: str, session_key: str, paper_id: str) -> None:
         await self._history_store.mark_chi_shi_paper_sent(zone, session_key, paper_id)
-
-    async def _send_push_to_targets(
-        self,
-        targets: list[str],
-        text: str,
-        png_file: Path,
-        pdf_file: Path,
-        pdf_url: str,
-        *,
-        send_semaphore: asyncio.Semaphore | None = None,
-    ) -> tuple[int, list[str]]:
-        return await self._run_batch_sender.send_push_to_targets(
-            targets=targets,
-            text=text,
-            png_file=png_file,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
-            send_semaphore=send_semaphore,
-        )
 
     def _build_push_text(
         self,
@@ -937,59 +554,6 @@ class ShitJournalDailyPlugin(Star):
                 f"{SUPABASE_KEY_ENV_NAME}",
             )
         return key
-
-    def _parse_command_action_arg(
-        self,
-        args: tuple[Any, ...],
-        kwargs: dict[str, Any],
-        default_action: str,
-    ) -> tuple[str, str]:
-        return self._command_gate.parse_command_action_arg(
-            args=args,
-            kwargs=kwargs,
-            default_action=default_action,
-        )
-
-    def _parse_action_arg_from_message(
-        self,
-        event: AstrMessageEvent,
-        command_name: str,
-    ) -> tuple[str, str]:
-        return self._command_gate.parse_action_arg_from_message(
-            event=event,
-            command_name=command_name,
-        )
-
-    def _pick_command_tokens(
-        self,
-        kwargs: dict[str, Any],
-        primary_key: str,
-        alias_key: str,
-        positional_value: Any,
-    ) -> list[str]:
-        if primary_key in kwargs:
-            tokens = self._split_command_tokens(kwargs.get(primary_key))
-            if tokens:
-                return tokens
-        if alias_key in kwargs:
-            tokens = self._split_command_tokens(kwargs.get(alias_key))
-            if tokens:
-                return tokens
-        return self._split_command_tokens(positional_value)
-
-    def _split_command_tokens(self, value: Any) -> list[str]:
-        if value is None:
-            return []
-        if isinstance(value, (list, tuple)):
-            tokens: list[str] = []
-            for item in value:
-                tokens.extend(self._split_command_tokens(item))
-            return tokens
-
-        text = str(value).strip().lower()
-        if not text:
-            return []
-        return [part for part in text.split() if part]
 
     def _cfg(self, key: str, default: Any) -> Any:
         try:
@@ -1083,12 +647,6 @@ class ShitJournalDailyPlugin(Star):
             return "目标分区和候补分区"
         return "目标分区"
 
-    def _parse_hhmm(self, value: str) -> tuple[int, int] | None:
-        return self._cron_scheduler.parse_hhmm(value)
-
-    def _normalize_schedule_times(self, raw: Any) -> list[str]:
-        return self._cron_scheduler.normalize_schedule_times(raw)
-
     def _normalize_session_list(self, raw: Any) -> list[str]:
         if not isinstance(raw, list):
             return []
@@ -1112,62 +670,3 @@ class ShitJournalDailyPlugin(Star):
             async with self._temp_trim_lock:
                 self._next_temp_trim_monotonic = 0.0
             raise
-
-    def _build_zone_fetch_warning_text(
-        self,
-        *,
-        zone: str,
-        is_primary: bool,
-        offset: int,
-        error: BaseException,
-    ) -> str:
-        zone_type = "主分区" if is_primary else "候补分区"
-        position = "首页" if offset == 0 else f"偏移={offset}"
-        error_text = mask_sensitive_text(str(error).strip()) or type(error).__name__
-        return f"{zone_type}抓取失败：分区={zone} {position} 错误={error_text}"
-
-    def _clean_warning_list(self, raw: Any) -> list[str]:
-        if not isinstance(raw, list):
-            return []
-        warnings: list[str] = []
-        seen: set[str] = set()
-        for item in raw:
-            text = mask_sensitive_text(str(item).strip())
-            if not text or text in seen:
-                continue
-            seen.add(text)
-            warnings.append(text)
-        return warnings
-
-    def _join_warning_text(self, warnings: list[str]) -> str:
-        return "；".join(self._clean_warning_list(warnings))
-
-    def _append_warning_lines(self, lines: list[str], warnings: list[str]) -> None:
-        for index, warning in enumerate(self._clean_warning_list(warnings), start=1):
-            lines.append(f"告警{index}: {warning}")
-
-    def _build_chi_shi_success_text(
-        self,
-        *,
-        requested_zone: str,
-        selected_zone: str,
-        warnings: list[str],
-    ) -> str:
-        return self._chi_shi_service.build_chi_shi_success_text(
-            requested_zone=requested_zone,
-            selected_zone=selected_zone,
-            warnings=warnings,
-        )
-
-    def _build_chi_shi_failure_text(
-        self,
-        *,
-        saw_candidates: bool,
-        warnings: list[str],
-        scope_label: str,
-    ) -> str:
-        return self._chi_shi_service.build_chi_shi_failure_text(
-            saw_candidates=saw_candidates,
-            warnings=warnings,
-            scope_label=scope_label,
-        )

--- a/main.py
+++ b/main.py
@@ -295,6 +295,7 @@ class ShitJournalDailyPlugin(Star):
                 session_key,
                 paper_id,
             ),
+            release_temp_files=lambda pdf_file, png_file: self._temp_files.release(pdf_file, png_file),
             get_primary_zone=self._get_primary_zone,
             get_candidate_zones=self._get_candidate_zones,
             build_zone_scope_text=self._build_zone_scope_text,

--- a/main.py
+++ b/main.py
@@ -16,12 +16,16 @@ from astrbot.api.star import Context, Star, StarTools, register
 
 if __package__:
     from .services import (
+        HistoryStore,
         PdfService,
         PushMessageService,
         RunBatch,
         RunBatchReport,
         RunReason,
         RunReport,
+        RunSelectionResult,
+        RunSelectionError,
+        RunSelector,
         RunStatus,
         SupabaseClient,
         TempFileManager,
@@ -33,12 +37,16 @@ else:
     if str(_plugin_dir) not in sys.path:
         sys.path.insert(0, str(_plugin_dir))
     from services import (
+        HistoryStore,
         PdfService,
         PushMessageService,
         RunBatch,
         RunBatchReport,
         RunReason,
         RunReport,
+        RunSelectionResult,
+        RunSelectionError,
+        RunSelector,
         RunStatus,
         SupabaseClient,
         TempFileManager,
@@ -56,12 +64,6 @@ MAX_SEND_CONCURRENCY = 20
 MAX_BATCH_SEND_CONCURRENCY = 2
 RUN_FETCH_PAGE_SIZE = 20
 CHI_SHI_FETCH_PAGE_SIZE = 20
-RUN_SENT_HISTORY_STORAGE_VERSION = "2"
-RUN_SENT_HISTORY_STORAGE_VERSION_KEY = "run_sent_history_storage_version"
-RUN_SENT_HISTORY_KV_PREFIX = "run_sent_history_v2::"
-CHI_SHI_HISTORY_STORAGE_VERSION = "2"
-CHI_SHI_HISTORY_STORAGE_VERSION_KEY = "chi_shi_sent_history_storage_version"
-CHI_SHI_HISTORY_KV_PREFIX = "chi_shi_sent_history_v2::"
 SUPABASE_KEY_ENV_NAME = "SUPABASE_PUBLISHABLE_KEY"
 TEMP_TRIM_INTERVAL_SEC = 60
 DISCIPLINE_LABELS: dict[str, tuple[str, str]] = {
@@ -107,12 +109,6 @@ REPORT_REASON_LABELS: dict[str, str] = {
 }
 
 
-class RunSelectionError(RuntimeError):
-    def __init__(self, reason_code: str, message: str = ""):
-        super().__init__(message or reason_code)
-        self.reason_code = reason_code
-
-
 @register(
     "astrbot_plugin_shitjournal_daily",
     "AstrBot",
@@ -124,15 +120,10 @@ class ShitJournalDailyPlugin(Star):
         super().__init__(context)
         self.config = config or {}
         self._run_lock = asyncio.Lock()
-        self._bound_sessions_lock = asyncio.Lock()
         self._cron_job_ids: list[str] = []
-        self._run_sent_history_lock = asyncio.Lock()
-        self._run_sent_history_storage_ready = False
         self._chi_shi_cooldown_lock = asyncio.Lock()
-        self._chi_shi_dedupe_lock = asyncio.Lock()
         self._chi_shi_group_cooldown_until_monotonic: dict[str, float] = {}
         self._chi_shi_group_inflight: set[str] = set()
-        self._chi_shi_history_storage_ready = False
         self._temp_trim_lock = asyncio.Lock()
         self._next_temp_trim_monotonic = 0.0
         self._plugin_data_dir = Path(".")
@@ -148,6 +139,30 @@ class ShitJournalDailyPlugin(Star):
         self._pdf_service = PdfService(cfg_int_getter=self._cfg_int)
         self._push_messages = PushMessageService(cfg_bool_getter=self._cfg_bool)
         self._temp_files = TempFileManager(self._temp_dir, cfg_int_getter=self._cfg_int)
+        self._history_store = HistoryStore(
+            kv_getter=self.get_kv_data,
+            kv_putter=self.put_kv_data,
+            cfg_bool_getter=self._cfg_bool,
+            cfg_int_getter=self._cfg_int,
+            normalize_session_list=self._normalize_session_list,
+            normalize_zone_name=self._normalize_zone_name,
+        )
+        self._run_selector = RunSelector(
+            fetch_latest_submissions=lambda zone, limit, offset: self._supabase.fetch_latest_submissions(
+                zone,
+                limit,
+                offset,
+            ),
+            get_run_sent_histories=lambda zone, targets: self._history_store.get_run_sent_histories(
+                zone,
+                targets,
+            ),
+            get_chi_shi_sent_history=lambda zone, session_key: self._history_store.get_chi_shi_sent_history(
+                zone,
+                session_key,
+            ),
+            logger=logger,
+        )
 
     async def initialize(self):
         self._plugin_data_dir = self._resolve_plugin_data_dir()
@@ -161,7 +176,7 @@ class ShitJournalDailyPlugin(Star):
             max_value=MAX_SEND_CONCURRENCY,
         )
         self._temp_dir.mkdir(parents=True, exist_ok=True)
-        await self._ensure_chi_shi_history_storage_ready()
+        await self._history_store.ensure_chi_shi_history_storage_ready()
         await self._clear_cron_jobs()
         await self._register_cron_jobs()
         await self._maybe_trim_temp_files(force=True)
@@ -208,7 +223,7 @@ class ShitJournalDailyPlugin(Star):
 
         if action == "bind":
             current = event.unified_msg_origin
-            if not await self._bind_session(current):
+            if not await self._history_store.bind_session(current):
                 yield event.plain_result(f"当前会话已绑定：{current}")
                 return
             yield event.plain_result(f"绑定成功：{current}")
@@ -216,7 +231,7 @@ class ShitJournalDailyPlugin(Star):
 
         if action == "unbind":
             current = event.unified_msg_origin
-            if not await self._unbind_session(current):
+            if not await self._history_store.unbind_session(current):
                 yield event.plain_result(f"当前会话未绑定：{current}")
                 return
             yield event.plain_result(f"解绑成功：{current}")
@@ -224,8 +239,8 @@ class ShitJournalDailyPlugin(Star):
 
         if action == "targets":
             cfg_targets = self._normalize_session_list(self._cfg("target_sessions", []))
-            bound = await self._get_bound_sessions()
-            merged = self._merge_sessions(cfg_targets, bound)
+            bound = await self._history_store.get_bound_sessions()
+            merged = await self._history_store.get_all_target_sessions(cfg_targets)
             if not merged:
                 yield event.plain_result("当前没有推送目标。可用 `/shitjournal bind` 绑定当前会话。")
                 return
@@ -287,71 +302,23 @@ class ShitJournalDailyPlugin(Star):
             yield event.plain_result(deny_reason)
             return
 
+        outputs: list[str] = []
         apply_success_cooldown = False
         pdf_file: Path | None = None
         png_file: Path | None = None
         try:
-            primary_zone = self._get_primary_zone()
-            zone_order = self._get_candidate_zones(primary_zone)
-            selected, saw_candidates, selection_warnings = await self._select_chi_shi_candidate_from_zones(
-                zone_order=zone_order,
-                session_key=session_key,
-            )
-            if not selected:
-                if selection_warnings:
-                    yield event.plain_result(
-                        self._build_chi_shi_failure_text(
-                            saw_candidates=saw_candidates,
-                            warnings=selection_warnings,
-                            scope_label=scope_label,
-                        ),
-                    )
-                    return
-                if saw_candidates:
-                    apply_success_cooldown = True
-                    yield event.plain_result(
-                        f"{scope_label}{self._build_zone_scope_text(zone_order)}最近这些论文都推送过了，等下一篇。",
-                    )
-                    return
-                yield event.plain_result("未找到最新论文。")
-                return
-
-            zone, candidate = selected
-
-            paper_id = str(candidate.get("id", "")).strip()
-            if not paper_id:
-                yield event.plain_result("候选论文缺少 ID。")
-                return
-
-            payload = await self._load_submission_payload(candidate, paper_id)
-            detail_url = self._build_preprint_detail_url(paper_id)
-            pdf_file, png_file, pdf_url = await self._prepare_pdf_assets(payload, paper_id)
-            text = self._build_push_text(payload, detail_url, zone=zone)
-            await self._push_messages.send_event_push(
+            outputs, apply_success_cooldown, pdf_file, png_file = await self._execute_wo_yao_chi_shi(
                 event=event,
-                text=text,
-                png_file=png_file,
-                pdf_file=pdf_file,
-                pdf_url=pdf_url,
+                session_key=session_key,
+                scope_label=scope_label,
             )
-            await self._mark_chi_shi_paper_sent(zone, session_key, paper_id)
-            apply_success_cooldown = True
-            if selection_warnings:
-                yield event.plain_result(
-                    self._build_chi_shi_success_text(
-                        requested_zone=primary_zone,
-                        selected_zone=zone,
-                        warnings=selection_warnings,
-                    ),
-                )
-            return
         except Exception as exc:
             logger.error(
                 "“我要赤石”指令执行失败：%s",
                 mask_sensitive_text(str(exc)),
                 exc_info=True,
             )
-            yield event.plain_result("抓取失败，请稍后重试。")
+            outputs = ["抓取失败，请稍后重试。"]
         finally:
             await self._leave_chi_shi_cooldown(
                 session_key=session_key,
@@ -363,6 +330,91 @@ class ShitJournalDailyPlugin(Star):
                 await self._maybe_trim_temp_files()
             except Exception:
                 logger.warning("“我要赤石”执行后清理临时文件失败。", exc_info=True)
+        for output in outputs:
+            yield event.plain_result(output)
+
+    async def _execute_wo_yao_chi_shi(
+        self,
+        *,
+        event: AstrMessageEvent,
+        session_key: str,
+        scope_label: str,
+    ) -> tuple[list[str], bool, Path | None, Path | None]:
+        primary_zone = self._get_primary_zone()
+        zone_order = self._get_candidate_zones(primary_zone)
+        selected, saw_candidates, selection_warnings = await self._run_selector.select_chi_shi_candidate_from_zones(
+            zone_order=zone_order,
+            session_key=session_key,
+            fetch_page_size=CHI_SHI_FETCH_PAGE_SIZE,
+        )
+        if not selected:
+            apply_success_cooldown, reply_text = self._build_missing_chi_shi_selection_response(
+                zone_order=zone_order,
+                scope_label=scope_label,
+                saw_candidates=saw_candidates,
+                selection_warnings=selection_warnings,
+            )
+            return [reply_text], apply_success_cooldown, None, None
+        apply_success_cooldown, pdf_file, png_file = await self._push_chi_shi_selection(
+            event=event,
+            session_key=session_key,
+            selection=selected,
+        )
+        if not apply_success_cooldown:
+            return ["候选论文缺少 ID。"], False, None, None
+        if not selection_warnings:
+            return [], True, pdf_file, png_file
+        return [
+            self._build_chi_shi_success_text(
+                requested_zone=primary_zone,
+                selected_zone=selected.zone,
+                warnings=selection_warnings,
+            ),
+        ], True, pdf_file, png_file
+
+    def _build_missing_chi_shi_selection_response(
+        self,
+        *,
+        zone_order: list[str],
+        scope_label: str,
+        saw_candidates: bool,
+        selection_warnings: list[str],
+    ) -> tuple[bool, str]:
+        if selection_warnings:
+            return False, self._build_chi_shi_failure_text(
+                saw_candidates=saw_candidates,
+                warnings=selection_warnings,
+                scope_label=scope_label,
+            )
+        if saw_candidates:
+            return True, f"{scope_label}{self._build_zone_scope_text(zone_order)}最近这些论文都推送过了，等下一篇。"
+        return False, "未找到最新论文。"
+
+    async def _push_chi_shi_selection(
+        self,
+        *,
+        event: AstrMessageEvent,
+        session_key: str,
+        selection: Any,
+    ) -> tuple[bool, Path | None, Path | None]:
+        zone = str(selection.zone).strip()
+        paper_id = str(selection.paper_id).strip()
+        candidate = dict(selection.candidate or {})
+        if not paper_id:
+            return False, None, None
+        payload = await self._load_submission_payload(candidate, paper_id)
+        detail_url = self._build_preprint_detail_url(paper_id)
+        pdf_file, png_file, pdf_url = await self._prepare_pdf_assets(payload, paper_id)
+        text = self._build_push_text(payload, detail_url, zone=zone)
+        await self._push_messages.send_event_push(
+            event=event,
+            text=text,
+            png_file=png_file,
+            pdf_file=pdf_file,
+            pdf_url=pdf_url,
+        )
+        await self._history_store.mark_chi_shi_paper_sent(zone, session_key, paper_id)
+        return True, pdf_file, png_file
 
     async def _check_command_permission(self, event: AstrMessageEvent) -> bool:
         if not self._looks_like_message_event(event):
@@ -609,588 +661,180 @@ class ShitJournalDailyPlugin(Star):
         latest_only: bool = False,
     ) -> RunReport:
         if self._run_lock.locked():
-            return RunReport(
-                status=RunStatus.SKIPPED,
-                reason_code=RunReason.RUN_IN_PROGRESS,
-                source=source,
-                debug_reason="",
-                latest_only=latest_only,
-            )
-
+            return self._build_run_in_progress_report(source=source, latest_only=latest_only)
         async with self._run_lock:
-            primary_zone = self._get_primary_zone()
-            zone_order = self._get_candidate_zones(primary_zone)
-            report = RunReport(
-                status=RunStatus.FAILED,
-                source=source,
-                zone=primary_zone,
-                requested_zone=primary_zone,
+            return await self._run_cycle_locked(
                 force=force,
+                source=source,
                 latest_only=latest_only,
             )
-            logger.info(
-                "开始执行推送：来源=%s 主分区=%s 分区顺序=%s 强制=%s 仅最新=%s",
-                source,
-                primary_zone,
-                zone_order,
-                force,
-                latest_only,
-            )
-            try:
-                targets = await self._get_all_target_sessions()
-                if not targets:
-                    report.reason_code = RunReason.NO_TARGET_SESSION_CONFIGURED
-                    return report
 
-                last_seen_map = await self._get_last_seen_map()
-                try:
-                    batches, saw_submission, last_seen_dirty, selection_warnings = await self._select_run_batches(
-                        zone_order=zone_order,
-                        targets=targets,
-                        last_seen_map=last_seen_map,
-                        force=force,
-                        latest_only=latest_only,
-                    )
-                except RunSelectionError as exc:
-                    message = str(exc).strip()
-                    report.reason_code = self._coerce_run_reason(exc.reason_code)
-                    logger.error(
-                        "获取最新论文失败：%s",
-                        mask_sensitive_text(message),
-                        exc_info=True,
-                    )
-                    report.debug_reason = mask_sensitive_text(message)
-                    return report
-                except RuntimeError as exc:
-                    message = str(exc).strip()
-                    logger.error(
-                        "获取最新论文失败：%s",
-                        mask_sensitive_text(message),
-                        exc_info=True,
-                    )
-                    report.reason_code = RunReason.FETCH_LATEST_FAILED
-                    report.debug_reason = mask_sensitive_text(message)
-                    return report
-                report.warnings = selection_warnings
-
-                if not batches:
-                    if selection_warnings:
-                        report.status = RunStatus.FAILED
-                        report.reason_code = RunReason.FETCH_LATEST_FAILED
-                        report.debug_reason = self._join_warning_text(selection_warnings)
-                        if last_seen_dirty:
-                            await self.put_kv_data("last_seen_by_zone", last_seen_map)
-                        return report
-                    report.status = RunStatus.SKIPPED
-                    report.reason_code = (
-                        RunReason.ALREADY_DELIVERED if saw_submission else RunReason.LATEST_NOT_FOUND
-                    )
-                    if last_seen_dirty:
-                        await self.put_kv_data("last_seen_by_zone", last_seen_map)
-                    return report
-
-                raw_batch_reports = await self._send_run_batches(
-                    batches,
-                    send_semaphore=asyncio.Semaphore(self._get_configured_send_concurrency()),
-                )
-                batch_reports = [self._coerce_run_batch_report(item) for item in raw_batch_reports]
-                report.batches = batch_reports
-                report.sent_ok = sum(batch.sent_ok for batch in batch_reports)
-                report.sent_total = sum(batch.sent_total for batch in batch_reports)
-                if batch_reports:
-                    first_batch = batch_reports[0]
-                    report.zone = first_batch.zone or primary_zone
-                    report.paper_id = first_batch.paper_id
-                    report.detail_url = first_batch.detail_url
-                first_debug_reason = self._pick_first_batch_debug_reason(batch_reports)
-                if first_debug_reason:
-                    report.debug_reason = first_debug_reason
-
-                if last_seen_dirty:
-                    await self.put_kv_data("last_seen_by_zone", last_seen_map)
-
-                report.status, report.reason_code = self._resolve_run_batch_reports(
-                    batch_reports=batch_reports,
-                    sent_ok=report.sent_ok,
-                    sent_total=report.sent_total,
-                )
-                return report
-            finally:
-                try:
-                    await self._maybe_trim_temp_files()
-                except Exception:
-                    logger.warning("执行推送后清理临时文件失败。", exc_info=True)
-
-    async def _select_chi_shi_candidate_from_zones(
-        self,
-        zone_order: list[str],
-        session_key: str,
-    ) -> tuple[tuple[str, dict[str, Any]] | None, bool, list[str]]:
-        saw_candidates = False
-        warnings: list[str] = []
-        for index, zone in enumerate(zone_order):
-            is_primary = index == 0
-            sent_set = set(await self._get_chi_shi_sent_history(zone, session_key))
-            offset = 0
-
-            while True:
-                try:
-                    candidates = await self._supabase.fetch_latest_submissions(
-                        zone,
-                        CHI_SHI_FETCH_PAGE_SIZE,
-                        offset,
-                    )
-                except Exception as exc:
-                    warnings.append(
-                        self._build_zone_fetch_warning_text(
-                            zone=zone,
-                            is_primary=is_primary,
-                            offset=offset,
-                            error=exc,
-                        ),
-                    )
-                    logger.warning(
-                        "获取“我要赤石”分区候选论文失败，已继续回退下一个分区：分区=%s 偏移=%s",
-                        zone,
-                        offset,
-                        exc_info=(type(exc), exc, exc.__traceback__),
-                    )
-                    break
-
-                if not candidates:
-                    break
-
-                saw_candidates = True
-                candidate = self._pick_first_unsent_candidate(candidates, sent_set)
-                if candidate:
-                    return (zone, candidate), True, warnings
-
-                if len(candidates) < CHI_SHI_FETCH_PAGE_SIZE:
-                    break
-                offset += len(candidates)
-
-        return None, saw_candidates, warnings
-
-    async def _select_run_batches(
+    async def _run_cycle_locked(
         self,
         *,
-        zone_order: list[str],
-        targets: list[str],
-        last_seen_map: dict[str, str],
+        force: bool,
+        source: str,
+        latest_only: bool,
+    ) -> RunReport:
+        primary_zone = self._get_primary_zone()
+        zone_order = self._get_candidate_zones(primary_zone)
+        report = self._build_run_cycle_report(source=source, primary_zone=primary_zone, force=force, latest_only=latest_only)
+        logger.info("开始执行推送：来源=%s 主分区=%s 分区顺序=%s 强制=%s 仅最新=%s", source, primary_zone, zone_order, force, latest_only)
+        try:
+            targets = await self._history_store.get_all_target_sessions(self._cfg("target_sessions", []))
+            if not targets:
+                report.reason_code = RunReason.NO_TARGET_SESSION_CONFIGURED
+                return report
+            previous_last_seen, selection = await self._select_run_cycle_batches(report=report, zone_order=zone_order, targets=targets, force=force, latest_only=latest_only)
+            if selection is None:
+                return report
+            if not selection.batches:
+                return await self._finalize_empty_run_selection(report=report, selection=selection, previous_last_seen=previous_last_seen)
+            batch_reports = await self._deliver_selected_run_batches(batches=selection.batches)
+            self._apply_run_batch_reports_to_report(report=report, batch_reports=batch_reports, primary_zone=primary_zone)
+            await self._persist_last_seen_map_if_changed(previous_last_seen=previous_last_seen, next_last_seen_map=selection.last_seen_map)
+            report.status, report.reason_code = self._resolve_run_batch_reports(batch_reports=batch_reports, sent_ok=report.sent_ok, sent_total=report.sent_total)
+            return report
+        finally:
+            try:
+                await self._maybe_trim_temp_files()
+            except Exception:
+                logger.warning("执行推送后清理临时文件失败。", exc_info=True)
+
+    def _build_run_in_progress_report(self, *, source: str, latest_only: bool) -> RunReport:
+        return RunReport(
+            status=RunStatus.SKIPPED,
+            reason_code=RunReason.RUN_IN_PROGRESS,
+            source=source,
+            debug_reason="",
+            latest_only=latest_only,
+        )
+
+    def _build_run_cycle_report(
+        self,
+        *,
+        source: str,
+        primary_zone: str,
         force: bool,
         latest_only: bool,
-    ) -> tuple[list[RunBatch], bool, bool, list[str]]:
-        if latest_only:
-            return await self._select_latest_only_run_batches(
-                zone_order=zone_order,
-                targets=targets,
-                last_seen_map=last_seen_map,
-                force=force,
-            )
+    ) -> RunReport:
+        return RunReport(
+            status=RunStatus.FAILED,
+            source=source,
+            zone=primary_zone,
+            requested_zone=primary_zone,
+            force=force,
+            latest_only=latest_only,
+        )
 
-        saw_submission = False
-        last_seen_dirty = False
-        unresolved_targets = targets.copy()
-        batches: list[RunBatch] = []
-        warnings: list[str] = []
-        for index, zone in enumerate(zone_order):
-            if not unresolved_targets:
-                break
-            first_page_candidates, zone_warnings = await self._fetch_run_candidates_page(
-                zone=zone,
-                is_primary=index == 0,
-                offset=0,
-            )
-            warnings.extend(zone_warnings)
-            if first_page_candidates is None:
-                continue
-            zone_batches, matched_targets, zone_saw_submission, zone_last_seen_dirty, page_warnings = (
-                await self._select_zone_run_batches(
-                    zone=zone,
-                    is_primary=index == 0,
-                    unresolved_targets=unresolved_targets,
-                    last_seen_map=last_seen_map,
-                    force=force,
-                    first_page_candidates=first_page_candidates,
-                )
-            )
-            warnings.extend(page_warnings)
-            batches.extend(zone_batches)
-            saw_submission = saw_submission or zone_saw_submission
-            last_seen_dirty = last_seen_dirty or zone_last_seen_dirty
-            unresolved_targets = self._subtract_targets(unresolved_targets, matched_targets)
-        return batches, saw_submission, last_seen_dirty, warnings
-
-    async def _select_latest_only_run_batches(
+    async def _select_run_cycle_batches(
         self,
         *,
+        report: RunReport,
         zone_order: list[str],
         targets: list[str],
-        last_seen_map: dict[str, str],
         force: bool,
-    ) -> tuple[list[RunBatch], bool, bool, list[str]]:
-        saw_submission = False
-        last_seen_dirty = False
-        unresolved_targets = targets.copy()
-        batches: list[RunBatch] = []
-        warnings: list[str] = []
-        for index, zone in enumerate(zone_order):
-            if not unresolved_targets:
-                break
-            first_page_candidates, zone_warnings = await self._fetch_run_candidates_page(
-                zone=zone,
-                is_primary=index == 0,
-                offset=0,
-            )
-            warnings.extend(zone_warnings)
-            if first_page_candidates is None:
-                continue
-            batch, matched_targets, zone_saw_submission, zone_last_seen_dirty = (
-                await self._select_latest_only_zone_batch(
-                    zone=zone,
-                    is_primary=index == 0,
-                    unresolved_targets=unresolved_targets,
-                    last_seen_map=last_seen_map,
-                    force=force,
-                    first_page_candidates=first_page_candidates,
-                )
-            )
-            if batch:
-                batches.append(batch)
-            saw_submission = saw_submission or zone_saw_submission
-            last_seen_dirty = last_seen_dirty or zone_last_seen_dirty
-            unresolved_targets = self._subtract_targets(unresolved_targets, matched_targets)
-        return batches, saw_submission, last_seen_dirty, warnings
-
-    async def _select_zone_run_batches(
-        self,
-        *,
-        zone: str,
-        is_primary: bool,
-        unresolved_targets: list[str],
-        last_seen_map: dict[str, str],
-        force: bool,
-        first_page_candidates: list[dict[str, Any]] | None,
-    ) -> tuple[list[RunBatch], set[str], bool, bool, list[str]]:
-        if not first_page_candidates:
-            return [], set(), False, False, []
-        sent_history_by_target = await self._get_run_sent_histories(zone, unresolved_targets)
-        sent_history_lookup_by_target = self._build_history_lookup(sent_history_by_target)
-        batches: list[RunBatch] = []
-        matched_targets: set[str] = set()
-        saw_submission = False
-        last_seen_dirty = False
-        zone_latest_recorded = False
-        offset = 0
-        warnings: list[str] = []
-        while True:
-            candidates, page_warnings = await self._load_run_candidates_page(
-                zone=zone,
-                is_primary=is_primary,
-                first_page_candidates=first_page_candidates,
-                offset=offset,
-            )
-            warnings.extend(page_warnings)
-            if candidates is None:
-                break
-            if not candidates:
-                break
-            saw_submission = True
-            page_batches, skip_zone, zone_latest_recorded, zone_last_seen_dirty, page_targets = (
-                self._build_zone_run_page_batches(
-                    zone=zone,
-                    candidates=candidates,
-                    offset=offset,
-                    unresolved_targets=unresolved_targets,
-                    matched_targets=matched_targets,
-                    sent_history_by_target=sent_history_by_target,
-                    sent_history_lookup_by_target=sent_history_lookup_by_target,
-                    force=force,
-                    is_primary=is_primary,
-                    zone_latest_recorded=zone_latest_recorded,
-                    last_seen_map=last_seen_map,
-                )
-            )
-            last_seen_dirty = last_seen_dirty or zone_last_seen_dirty
-            batches.extend(page_batches)
-            matched_targets.update(page_targets)
-            if skip_zone or len(candidates) < RUN_FETCH_PAGE_SIZE or len(matched_targets) == len(unresolved_targets):
-                break
-            offset += len(candidates)
-        return batches, matched_targets, saw_submission, last_seen_dirty, warnings
-
-    async def _select_latest_only_zone_batch(
-        self,
-        *,
-        zone: str,
-        is_primary: bool,
-        unresolved_targets: list[str],
-        last_seen_map: dict[str, str],
-        force: bool,
-        first_page_candidates: list[dict[str, Any]] | None,
-    ) -> tuple[RunBatch | None, set[str], bool, bool]:
-        candidates = first_page_candidates
-        if not candidates:
-            return None, set(), False, False
-        candidate = candidates[0]
-        paper_id = self._extract_run_candidate_paper_id(
-            zone=zone,
-            candidate=candidate,
-            is_primary=is_primary,
-        )
-        if paper_id is None:
-            return None, set(), True, False
-        last_seen_dirty = False
-        if last_seen_map.get(zone) != paper_id:
-            last_seen_map[zone] = paper_id
-            last_seen_dirty = True
-        sent_history_by_target = await self._get_run_sent_histories(zone, unresolved_targets)
-        sent_history_lookup_by_target = self._build_history_lookup(sent_history_by_target)
-        matched_targets = self._match_run_batch_targets(
-            paper_id=paper_id,
-            unresolved_targets=unresolved_targets,
-            matched_targets=set(),
-            sent_history_lookup_by_target=sent_history_lookup_by_target,
-            force=force,
-        )
-        if not matched_targets:
-            return None, set(), True, last_seen_dirty
-        batch = self._build_run_batch(
-            zone=zone,
-            candidate=candidate,
-            paper_id=paper_id,
-            targets=matched_targets,
-            sent_history_by_target=sent_history_by_target,
-            sent_history_lookup_by_target=sent_history_lookup_by_target,
-        )
-        return batch, set(matched_targets), True, last_seen_dirty
-
-    async def _load_run_candidates_page(
-        self,
-        *,
-        zone: str,
-        is_primary: bool,
-        first_page_candidates: list[dict[str, Any]] | None,
-        offset: int,
-    ) -> tuple[list[dict[str, Any]] | None, list[str]]:
-        if offset == 0:
-            return first_page_candidates, []
-        return await self._fetch_run_candidates_page(
-            zone=zone,
-            is_primary=is_primary,
-            offset=offset,
-        )
-
-    def _build_zone_run_page_batches(
-        self,
-        *,
-        zone: str,
-        candidates: list[dict[str, Any]],
-        offset: int,
-        unresolved_targets: list[str],
-        matched_targets: set[str],
-        sent_history_by_target: dict[str, list[str]],
-        sent_history_lookup_by_target: dict[str, set[str]],
-        force: bool,
-        is_primary: bool,
-        zone_latest_recorded: bool,
-        last_seen_map: dict[str, str],
-    ) -> tuple[list[RunBatch], bool, bool, bool, set[str]]:
-        page_batches: list[RunBatch] = []
-        page_targets: set[str] = set()
-        occupied_targets = set(matched_targets)
-        last_seen_dirty = False
-        for candidate_index, candidate in enumerate(candidates):
-            paper_id = str(candidate.get("id", "")).strip()
-            if not paper_id:
-                if offset == 0 and candidate_index == 0:
-                    paper_id = self._extract_run_candidate_paper_id(
-                        zone=zone,
-                        is_primary=is_primary,
-                        candidate=candidate,
-                    )
-                    if paper_id is None:
-                        return [], True, zone_latest_recorded, last_seen_dirty, page_targets
-                else:
-                    logger.warning(
-                        "候选论文缺少 ID，已跳过：分区=%s 载荷=%s",
-                        zone,
-                        json.dumps(self._build_meta_preview(candidate), ensure_ascii=False),
-                    )
-                    continue
-            if not zone_latest_recorded:
-                logger.info(
-                    "已获取最新论文：分区=%s 论文ID=%s 详情=%s",
-                    zone,
-                    paper_id,
-                    self._build_preprint_detail_url(paper_id),
-                )
-                zone_latest_recorded = True
-                if last_seen_map.get(zone) != paper_id:
-                    last_seen_map[zone] = paper_id
-                    last_seen_dirty = True
-            batch_targets = self._match_run_batch_targets(
-                paper_id=paper_id,
-                unresolved_targets=unresolved_targets,
-                matched_targets=occupied_targets,
-                sent_history_lookup_by_target=sent_history_lookup_by_target,
-                force=force,
-            )
-            if not batch_targets:
-                continue
-            page_batches.append(
-                self._build_run_batch(
-                    zone=zone,
-                    candidate=candidate,
-                    paper_id=paper_id,
-                    targets=batch_targets,
-                    sent_history_by_target=sent_history_by_target,
-                    sent_history_lookup_by_target=sent_history_lookup_by_target,
-                )
-            )
-            page_targets.update(batch_targets)
-            occupied_targets.update(batch_targets)
-        return page_batches, False, zone_latest_recorded, last_seen_dirty, page_targets
-
-    def _subtract_targets(self, targets: list[str], removed_targets: set[str]) -> list[str]:
-        if not removed_targets:
-            return targets
-        return [target for target in targets if target not in removed_targets]
-
-    def _match_run_batch_targets(
-        self,
-        *,
-        paper_id: str,
-        unresolved_targets: list[str],
-        matched_targets: set[str],
-        sent_history_lookup_by_target: dict[str, set[str]],
-        force: bool,
-    ) -> list[str]:
-        pending_targets: list[str] = []
-        for session in unresolved_targets:
-            if session in matched_targets:
-                continue
-            if not force:
-                history_lookup = sent_history_lookup_by_target.get(session)
-                if history_lookup is not None and paper_id in history_lookup:
-                    continue
-            pending_targets.append(session)
-        return pending_targets
-
-    def _build_run_batch(
-        self,
-        *,
-        zone: str,
-        candidate: dict[str, Any],
-        paper_id: str,
-        targets: list[str],
-        sent_history_by_target: dict[str, list[str]],
-        sent_history_lookup_by_target: dict[str, set[str]],
-    ) -> RunBatch:
-        return RunBatch(
-            zone=zone,
-            latest=candidate,
-            paper_id=paper_id,
-            detail_url=self._build_preprint_detail_url(paper_id),
-            targets=targets,
-            sent_history_by_target=sent_history_by_target,
-            sent_history_lookup_by_target=sent_history_lookup_by_target,
-        )
-
-    async def _fetch_run_candidates_page(
-        self,
-        *,
-        zone: str,
-        is_primary: bool,
-        offset: int,
-    ) -> tuple[list[dict[str, Any]] | None, list[str]]:
+        latest_only: bool,
+    ) -> tuple[dict[str, str], RunSelectionResult | None]:
+        previous_last_seen = await self._history_store.get_last_seen_map()
         try:
-            return await self._supabase.fetch_latest_submissions(zone, RUN_FETCH_PAGE_SIZE, offset), []
-        except Exception as exc:
-            warning = self._build_zone_fetch_warning_text(
-                zone=zone,
-                is_primary=is_primary,
-                offset=offset,
-                error=exc,
+            selection = await self._run_selector.select_run_batches(
+                zone_order=zone_order,
+                targets=targets,
+                last_seen_map=previous_last_seen,
+                force=force,
+                latest_only=latest_only,
+                fetch_page_size=RUN_FETCH_PAGE_SIZE,
             )
-            self._log_run_candidate_fetch_warning(
-                zone=zone,
-                is_primary=is_primary,
-                offset=offset,
-                error=exc,
+        except RunSelectionError as exc:
+            self._apply_run_selection_error(
+                report=report,
+                reason_code=self._coerce_run_reason(exc.reason_code),
+                message=str(exc).strip(),
             )
-            return None, [warning]
+            return previous_last_seen, None
+        except RuntimeError as exc:
+            self._apply_run_selection_error(
+                report=report,
+                reason_code=RunReason.FETCH_LATEST_FAILED,
+                message=str(exc).strip(),
+            )
+            return previous_last_seen, None
+        report.warnings = selection.warnings
+        return previous_last_seen, selection
 
-    def _log_run_candidate_fetch_warning(
+    def _apply_run_selection_error(
         self,
         *,
-        zone: str,
-        is_primary: bool,
-        offset: int,
-        error: BaseException,
+        report: RunReport,
+        reason_code: RunReason,
+        message: str,
     ) -> None:
-        if offset == 0:
-            zone_type = "主分区" if is_primary else "候补分区"
-            logger.warning(
-                "获取%s最新论文失败，已继续回退后续分区：分区=%s",
-                zone_type,
-                zone,
-                exc_info=(type(error), error, error.__traceback__),
+        report.reason_code = reason_code
+        logger.error("获取最新论文失败：%s", mask_sensitive_text(message), exc_info=True)
+        report.debug_reason = mask_sensitive_text(message)
+
+    async def _finalize_empty_run_selection(
+        self,
+        *,
+        report: RunReport,
+        selection: RunSelectionResult,
+        previous_last_seen: dict[str, str],
+    ) -> RunReport:
+        if selection.warnings:
+            report.status = RunStatus.FAILED
+            report.reason_code = RunReason.FETCH_LATEST_FAILED
+            report.debug_reason = self._join_warning_text(selection.warnings)
+        else:
+            report.status = RunStatus.SKIPPED
+            report.reason_code = (
+                RunReason.ALREADY_DELIVERED if selection.saw_submission else RunReason.LATEST_NOT_FOUND
             )
+        await self._persist_last_seen_map_if_changed(
+            previous_last_seen=previous_last_seen,
+            next_last_seen_map=selection.last_seen_map,
+        )
+        return report
+
+    async def _deliver_selected_run_batches(
+        self,
+        *,
+        batches: list[RunBatch],
+    ) -> list[RunBatchReport]:
+        raw_batch_reports = await self._send_run_batches(
+            batches,
+            send_semaphore=asyncio.Semaphore(self._get_configured_send_concurrency()),
+        )
+        return [self._coerce_run_batch_report(item) for item in raw_batch_reports]
+
+    def _apply_run_batch_reports_to_report(
+        self,
+        *,
+        report: RunReport,
+        batch_reports: list[RunBatchReport],
+        primary_zone: str,
+    ) -> None:
+        report.batches = batch_reports
+        report.sent_ok = sum(batch.sent_ok for batch in batch_reports)
+        report.sent_total = sum(batch.sent_total for batch in batch_reports)
+        if batch_reports:
+            first_batch = batch_reports[0]
+            report.zone = first_batch.zone or primary_zone
+            report.paper_id = first_batch.paper_id
+            report.detail_url = first_batch.detail_url
+        first_debug_reason = self._pick_first_batch_debug_reason(batch_reports)
+        if first_debug_reason:
+            report.debug_reason = first_debug_reason
+
+    async def _persist_last_seen_map_if_changed(
+        self,
+        *,
+        previous_last_seen: dict[str, str],
+        next_last_seen_map: dict[str, str],
+    ) -> None:
+        if previous_last_seen == next_last_seen_map:
             return
-        zone_type = "主分区" if is_primary else "候补分区"
-        logger.warning(
-            "获取%s候选页失败，已停止继续检查该分区并回退后续分区：分区=%s 偏移=%s",
-            zone_type,
-            zone,
-            offset,
-            exc_info=(type(error), error, error.__traceback__),
-        )
-
-    def _raise_run_candidate_id_error(
-        self,
-        *,
-        zone: str,
-        is_primary: bool,
-        candidate: dict[str, Any],
-    ) -> None:
-        zone_type = "主分区最新论文" if is_primary else "候补分区最新论文"
-        meta_preview = json.dumps(self._build_meta_preview(candidate), ensure_ascii=False)
-        raise RunSelectionError(
-            "EMPTY_PAPER_ID",
-            f"{zone_type}缺少 ID：分区={zone} 载荷={meta_preview}",
-        )
-
-    def _log_run_candidate_id_warning(
-        self,
-        *,
-        zone: str,
-        candidate: dict[str, Any],
-    ) -> None:
-        logger.warning(
-            "候补分区最新论文缺少 ID，已跳过该分区：分区=%s 载荷=%s",
-            zone,
-            json.dumps(self._build_meta_preview(candidate), ensure_ascii=False),
-        )
-
-    def _extract_run_candidate_paper_id(
-        self,
-        *,
-        zone: str,
-        candidate: dict[str, Any],
-        is_primary: bool,
-    ) -> str | None:
-        paper_id = str(candidate.get("id", "")).strip()
-        if paper_id:
-            return paper_id
-        if is_primary:
-            self._raise_run_candidate_id_error(
-                zone=zone,
-                is_primary=is_primary,
-                candidate=candidate,
-            )
-        self._log_run_candidate_id_warning(zone=zone, candidate=candidate)
-        return None
+        await self._history_store.set_last_seen_map(next_last_seen_map)
 
     async def _send_run_batches(
         self,
@@ -1216,13 +860,18 @@ class ShitJournalDailyPlugin(Star):
         *,
         send_semaphore: asyncio.Semaphore | None = None,
     ) -> RunBatchReport:
-        zone = str(batch.zone)
-        latest = dict(batch.latest)
-        paper_id = str(batch.paper_id)
-        detail_url = str(batch.detail_url)
-        targets = list(batch.targets)
-        sent_history_by_target = dict(batch.sent_history_by_target)
-        sent_history_lookup_by_target = dict(batch.sent_history_lookup_by_target)
+        try:
+            return await self._send_run_batch_inner(batch=batch, send_semaphore=send_semaphore)
+        finally:
+            pass
+
+    async def _send_run_batch_inner(
+        self,
+        *,
+        batch: RunBatch,
+        send_semaphore: asyncio.Semaphore | None,
+    ) -> RunBatchReport:
+        zone, latest, paper_id, detail_url, targets = self._unpack_run_batch(batch)
         report = self._build_run_batch_report(
             zone=zone,
             paper_id=paper_id,
@@ -1232,15 +881,10 @@ class ShitJournalDailyPlugin(Star):
         pdf_file: Path | None = None
         png_file: Path | None = None
         try:
-            payload = await self._load_submission_payload(latest, paper_id)
-            logger.info(
-                "论文元数据：%s",
-                json.dumps(self._build_meta_preview(payload), ensure_ascii=False),
-            )
-            pdf_file, png_file, pdf_url = await self._prepare_pdf_assets(payload, paper_id)
-            text = self._build_push_text(
-                payload,
-                detail_url,
+            payload, pdf_file, png_file, pdf_url, text = await self._prepare_run_batch_delivery(
+                latest=latest,
+                paper_id=paper_id,
+                detail_url=detail_url,
                 zone=zone,
             )
             sent_ok, sent_success_targets = await self._send_push_to_targets(
@@ -1252,42 +896,20 @@ class ShitJournalDailyPlugin(Star):
                 send_semaphore=send_semaphore,
             )
             report.sent_ok = sent_ok
-            if sent_success_targets:
-                await self._mark_targets_delivered(
-                    zone=zone,
-                    paper_id=paper_id,
-                    success_targets=sent_success_targets,
-                    sent_history_by_target=sent_history_by_target,
-                    sent_history_lookup_by_target=sent_history_lookup_by_target,
-                )
+            await self._persist_run_batch_success_targets(
+                zone=zone,
+                paper_id=paper_id,
+                success_targets=sent_success_targets,
+            )
             report.status = self._resolve_send_status(sent_ok=sent_ok, sent_total=len(targets))
             report.reason_code = self._resolve_send_reason_code(report.status)
             return report
         except Exception as exc:
-            if report.sent_ok > 0:
-                logger.error(
-                    "写入推送去重状态失败：分区=%s 论文ID=%s 错误=%s",
-                    zone,
-                    paper_id,
-                    mask_sensitive_text(str(exc)),
-                    exc_info=True,
-                )
-                return self._build_failed_run_batch_report(
-                    report=report,
-                    reason_code=RunReason.DELIVERY_STATE_WRITE_FAILED,
-                    debug_reason=str(exc),
-                )
-            logger.error(
-                "批次推送失败：分区=%s 论文ID=%s 错误=%s",
-                zone,
-                paper_id,
-                mask_sensitive_text(str(exc)),
-                exc_info=True,
-            )
-            return self._build_failed_run_batch_report(
+            return self._build_run_batch_exception_report(
                 report=report,
-                reason_code=RunReason.ALL_SENDS_FAILED,
-                debug_reason=str(exc),
+                zone=zone,
+                paper_id=paper_id,
+                error=exc,
             )
         finally:
             await self._temp_files.release(pdf_file, png_file)
@@ -1295,6 +917,81 @@ class ShitJournalDailyPlugin(Star):
                 await self._maybe_trim_temp_files()
             except Exception:
                 logger.warning("批次推送后清理临时文件失败。", exc_info=True)
+
+    def _unpack_run_batch(
+        self,
+        batch: RunBatch,
+    ) -> tuple[str, dict[str, Any], str, str, list[str]]:
+        return (
+            str(batch.zone),
+            dict(batch.latest),
+            str(batch.paper_id),
+            str(batch.detail_url),
+            list(batch.targets),
+        )
+
+    async def _prepare_run_batch_delivery(
+        self,
+        *,
+        latest: dict[str, Any],
+        paper_id: str,
+        detail_url: str,
+        zone: str,
+    ) -> tuple[dict[str, Any], Path | None, Path | None, str, str]:
+        payload = await self._load_submission_payload(latest, paper_id)
+        logger.info("论文元数据：%s", json.dumps(self._build_meta_preview(payload), ensure_ascii=False))
+        pdf_file, png_file, pdf_url = await self._prepare_pdf_assets(payload, paper_id)
+        text = self._build_push_text(payload, detail_url, zone=zone)
+        return payload, pdf_file, png_file, pdf_url, text
+
+    async def _persist_run_batch_success_targets(
+        self,
+        *,
+        zone: str,
+        paper_id: str,
+        success_targets: list[str],
+    ) -> None:
+        if not success_targets:
+            return
+        await self._history_store.mark_run_targets_delivered(
+            zone=zone,
+            paper_id=paper_id,
+            success_targets=success_targets,
+        )
+
+    def _build_run_batch_exception_report(
+        self,
+        *,
+        report: RunBatchReport,
+        zone: str,
+        paper_id: str,
+        error: Exception,
+    ) -> RunBatchReport:
+        if report.sent_ok > 0:
+            logger.error(
+                "写入推送去重状态失败：分区=%s 论文ID=%s 错误=%s",
+                zone,
+                paper_id,
+                mask_sensitive_text(str(error)),
+                exc_info=True,
+            )
+            return self._build_failed_run_batch_report(
+                report=report,
+                reason_code=RunReason.DELIVERY_STATE_WRITE_FAILED,
+                debug_reason=str(error),
+            )
+        logger.error(
+            "批次推送失败：分区=%s 论文ID=%s 错误=%s",
+            zone,
+            paper_id,
+            mask_sensitive_text(str(error)),
+            exc_info=True,
+        )
+        return self._build_failed_run_batch_report(
+            report=report,
+            reason_code=RunReason.ALL_SENDS_FAILED,
+            debug_reason=str(error),
+        )
 
     def _build_run_batch_report(
         self,
@@ -1828,281 +1525,6 @@ class ShitJournalDailyPlugin(Star):
                 normalized.append(text)
         return normalized
 
-    def _merge_sessions(self, first: list[str], second: list[str]) -> list[str]:
-        merged: list[str] = []
-        seen = set()
-        for item in first + second:
-            if item in seen:
-                continue
-            seen.add(item)
-            merged.append(item)
-        return merged
-
-    async def _get_bound_sessions(self) -> list[str]:
-        raw = await self.get_kv_data("bound_sessions", [])
-        return self._normalize_session_list(raw)
-
-    async def _set_bound_sessions(self, sessions: list[str]) -> None:
-        normalized = self._normalize_session_list(sessions)
-        await self.put_kv_data("bound_sessions", normalized)
-
-    async def _bind_session(self, session: str) -> bool:
-        async with self._bound_sessions_lock:
-            bound = await self._get_bound_sessions()
-            if session in bound:
-                return False
-            bound.append(session)
-            await self._set_bound_sessions(bound)
-            return True
-
-    async def _unbind_session(self, session: str) -> bool:
-        async with self._bound_sessions_lock:
-            bound = await self._get_bound_sessions()
-            if session not in bound:
-                return False
-            updated = [item for item in bound if item != session]
-            await self._set_bound_sessions(updated)
-            return True
-
-    async def _get_all_target_sessions(self) -> list[str]:
-        cfg_targets = self._normalize_session_list(self._cfg("target_sessions", []))
-        bound = await self._get_bound_sessions()
-        return self._merge_sessions(cfg_targets, bound)
-
-    async def _get_last_seen_map(self) -> dict[str, str]:
-        raw = await self.get_kv_data("last_seen_by_zone", {})
-        return self._clean_kv_dict(raw)
-
-    def _run_history_store_key(self, zone: str, session: str) -> str:
-        return f"{RUN_SENT_HISTORY_KV_PREFIX}{self._target_zone_key(zone, session)}"
-
-    def _normalize_target_zone_key(self, raw_key: Any) -> str:
-        text = str(raw_key or "").strip()
-        if not text:
-            return ""
-        zone, sep, session = text.partition("::")
-        if not sep:
-            return ""
-        session = session.strip()
-        if not session:
-            return ""
-        return self._target_zone_key(zone, session)
-
-    async def _ensure_run_sent_history_storage_ready(self) -> None:
-        if self._run_sent_history_storage_ready:
-            return
-        async with self._run_sent_history_lock:
-            if self._run_sent_history_storage_ready:
-                return
-
-            version = str(await self.get_kv_data(RUN_SENT_HISTORY_STORAGE_VERSION_KEY, "") or "").strip()
-            if version == RUN_SENT_HISTORY_STORAGE_VERSION:
-                self._run_sent_history_storage_ready = True
-                return
-
-            legacy_raw = await self.get_kv_data("last_sent_by_target_zone", {})
-            merged = self._build_legacy_run_sent_histories(legacy_raw)
-            for target_zone_key, history in merged.items():
-                zone, _, session = target_zone_key.partition("::")
-                if not session:
-                    continue
-                await self.put_kv_data(self._run_history_store_key(zone, session), history)
-            if legacy_raw:
-                await self.put_kv_data("last_sent_by_target_zone", {})
-            await self.put_kv_data(RUN_SENT_HISTORY_STORAGE_VERSION_KEY, RUN_SENT_HISTORY_STORAGE_VERSION)
-            self._run_sent_history_storage_ready = True
-
-    def _build_legacy_run_sent_histories(self, legacy_raw: Any) -> dict[str, list[str]]:
-        merged: dict[str, list[str]] = {}
-        for raw_key, paper_id in self._clean_kv_dict(legacy_raw).items():
-            key = self._normalize_target_zone_key(raw_key)
-            if not key:
-                continue
-            merged[key] = [paper_id]
-
-        return merged
-
-    async def _get_run_sent_history(self, zone: str, session: str) -> list[str]:
-        await self._ensure_run_sent_history_storage_ready()
-        return await self._get_run_sent_history_unlocked(zone, session)
-
-    async def _get_run_sent_history_unlocked(self, zone: str, session: str) -> list[str]:
-        raw = await self.get_kv_data(self._run_history_store_key(zone, session), [])
-        return self._clean_kv_list(raw)
-
-    async def _get_run_sent_histories(self, zone: str, targets: list[str]) -> dict[str, list[str]]:
-        await self._ensure_run_sent_history_storage_ready()
-        raw_histories = await asyncio.gather(
-            *[self.get_kv_data(self._run_history_store_key(zone, session), []) for session in targets],
-        )
-        return {
-            session: self._clean_kv_list(raw_history)
-            for session, raw_history in zip(targets, raw_histories)
-        }
-
-    def _chi_shi_group_zone_key(self, zone: str, session: str) -> str:
-        return f"{self._normalize_zone_name(zone)}::{session}"
-
-    def _chi_shi_history_store_key(self, zone: str, session: str) -> str:
-        return f"{CHI_SHI_HISTORY_KV_PREFIX}{self._chi_shi_group_zone_key(zone, session)}"
-
-    def _normalize_group_zone_key(self, raw_key: Any) -> str:
-        text = str(raw_key or "").strip()
-        if not text:
-            return ""
-        zone, sep, session = text.partition("::")
-        if not sep:
-            return ""
-        session = session.strip()
-        if not session:
-            return ""
-        return self._chi_shi_group_zone_key(zone, session)
-
-    async def _ensure_chi_shi_history_storage_ready(self) -> None:
-        if self._chi_shi_history_storage_ready:
-            return
-        async with self._chi_shi_dedupe_lock:
-            if self._chi_shi_history_storage_ready:
-                return
-
-            version = str(await self.get_kv_data(CHI_SHI_HISTORY_STORAGE_VERSION_KEY, "") or "").strip()
-            if version == CHI_SHI_HISTORY_STORAGE_VERSION:
-                self._chi_shi_history_storage_ready = True
-                return
-
-            merged = await self._load_legacy_chi_shi_histories()
-            for group_zone_key, history in merged.items():
-                zone, _, session = group_zone_key.partition("::")
-                if not session:
-                    continue
-                await self.put_kv_data(self._chi_shi_history_store_key(zone, session), history)
-            await self.put_kv_data(CHI_SHI_HISTORY_STORAGE_VERSION_KEY, CHI_SHI_HISTORY_STORAGE_VERSION)
-            self._chi_shi_history_storage_ready = True
-
-    async def _load_legacy_chi_shi_histories(self) -> dict[str, list[str]]:
-        history_raw = await self.get_kv_data("chi_shi_sent_history_by_group_zone", {})
-        legacy_raw = await self.get_kv_data("chi_shi_last_sent_by_group_zone", {})
-
-        merged: dict[str, list[str]] = {}
-        for raw_key, history in self._clean_kv_list_dict(history_raw).items():
-            key = self._normalize_group_zone_key(raw_key)
-            if not key:
-                continue
-            merged[key] = self._apply_chi_shi_history_policy(history)
-
-        for raw_key, paper_id in self._clean_kv_dict(legacy_raw).items():
-            key = self._normalize_group_zone_key(raw_key)
-            if not key:
-                continue
-            history = merged.get(key, [])
-            if paper_id not in history:
-                history = history + [paper_id]
-            merged[key] = self._apply_chi_shi_history_policy(history)
-
-        return {key: history for key, history in merged.items() if history}
-
-    async def _get_chi_shi_sent_history(self, zone: str, session: str) -> list[str]:
-        await self._ensure_chi_shi_history_storage_ready()
-        async with self._chi_shi_dedupe_lock:
-            return await self._get_chi_shi_sent_history_unlocked(zone, session)
-
-    async def _get_chi_shi_sent_history_unlocked(self, zone: str, session: str) -> list[str]:
-        raw = await self.get_kv_data(self._chi_shi_history_store_key(zone, session), [])
-        return self._apply_chi_shi_history_policy(self._clean_kv_list(raw))
-
-    def _pick_first_unsent_candidate(
-        self,
-        candidates: list[dict[str, Any]],
-        sent_set: set[str],
-    ) -> dict[str, Any] | None:
-        for candidate in candidates:
-            paper_id = str(candidate.get("id", "")).strip()
-            if paper_id and paper_id not in sent_set:
-                return candidate
-        return None
-
-    async def _mark_chi_shi_paper_sent(
-        self,
-        zone: str,
-        session: str,
-        paper_id: str,
-    ) -> None:
-        await self._ensure_chi_shi_history_storage_ready()
-        async with self._chi_shi_dedupe_lock:
-            history = await self._get_chi_shi_sent_history_unlocked(zone, session)
-            await self.put_kv_data(
-                self._chi_shi_history_store_key(zone, session),
-                self._apply_chi_shi_history_policy(self._prepend_history_item(history, paper_id)),
-            )
-
-    def _apply_chi_shi_history_policy(self, history: list[str]) -> list[str]:
-        if self._cfg_bool("chi_shi_keep_full_history", True):
-            return history
-
-        limit = self._cfg_int("chi_shi_history_limit", 30, min_value=1)
-        return history[:limit]
-
-    def _clean_kv_dict(self, raw: Any) -> dict[str, str]:
-        if not isinstance(raw, dict):
-            return {}
-        result: dict[str, str] = {}
-        for key, value in raw.items():
-            key_s = str(key).strip()
-            val_s = str(value).strip()
-            if key_s and val_s:
-                result[key_s] = val_s
-        return result
-
-    def _clean_kv_list(self, raw: Any) -> list[str]:
-        values = raw if isinstance(raw, list) else [raw]
-        cleaned: list[str] = []
-        seen: set[str] = set()
-        for item in values:
-            item_s = str(item).strip()
-            if not item_s or item_s in seen:
-                continue
-            seen.add(item_s)
-            cleaned.append(item_s)
-        return cleaned
-
-    def _prepend_history_item(self, history: list[str], item: str) -> list[str]:
-        value = str(item).strip()
-        if not value:
-            return history
-        updated = [entry for entry in history if entry != value]
-        updated.insert(0, value)
-        return updated
-
-    def _build_history_lookup(self, history_by_target: dict[str, list[str]]) -> dict[str, set[str]]:
-        return {session: set(history) for session, history in history_by_target.items()}
-
-    def _clean_kv_list_dict(self, raw: Any) -> dict[str, list[str]]:
-        if not isinstance(raw, dict):
-            return {}
-        result: dict[str, list[str]] = {}
-        for key, value in raw.items():
-            key_s = str(key).strip()
-            if not key_s:
-                continue
-            if isinstance(value, list):
-                values = value
-            else:
-                values = [value]
-            cleaned: list[str] = []
-            seen: set[str] = set()
-            for item in values:
-                item_s = str(item).strip()
-                if not item_s or item_s in seen:
-                    continue
-                seen.add(item_s)
-                cleaned.append(item_s)
-            if cleaned:
-                result[key_s] = cleaned
-        return result
-
-    def _target_zone_key(self, zone: str, session: str) -> str:
-        return f"{self._normalize_zone_name(zone)}::{session}"
-
     async def _maybe_trim_temp_files(self, *, force: bool = False) -> None:
         async with self._temp_trim_lock:
             now = time.monotonic()
@@ -2116,37 +1538,6 @@ class ShitJournalDailyPlugin(Star):
             async with self._temp_trim_lock:
                 self._next_temp_trim_monotonic = 0.0
             raise
-
-    async def _mark_targets_delivered(
-        self,
-        zone: str,
-        paper_id: str,
-        success_targets: list[str],
-        sent_history_by_target: dict[str, list[str]],
-        sent_history_lookup_by_target: dict[str, set[str]],
-    ) -> None:
-        await self._ensure_run_sent_history_storage_ready()
-        pending_writes: list[tuple[str, list[str]]] = []
-        async with self._run_sent_history_lock:
-            for session in success_targets:
-                history = sent_history_by_target.get(session)
-                if history is None:
-                    history = await self._get_run_sent_history_unlocked(zone, session)
-                else:
-                    history = list(history)
-                history = self._prepend_history_item(history, paper_id)
-                sent_history_by_target[session] = history
-                history_lookup = sent_history_lookup_by_target.get(session)
-                if history_lookup is None:
-                    history_lookup = set(history)
-                    sent_history_lookup_by_target[session] = history_lookup
-                else:
-                    history_lookup.add(paper_id)
-                pending_writes.append((self._run_history_store_key(zone, session), history))
-
-        await asyncio.gather(
-            *[self.put_kv_data(store_key, history) for store_key, history in pending_writes],
-        )
 
     def _format_datetime(self, value: Any) -> str:
         text = str(value or "").strip()

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 import re
 import sys
@@ -16,12 +15,17 @@ from astrbot.api.star import Context, Star, StarTools, register
 if __package__:
     from .services import (
         AssetPipeline,
+        ChiShiService,
+        CommandGate,
+        CronScheduler,
         HistoryStore,
         PdfService,
         PushMessageService,
         ReportRenderer,
         RunBatch,
         RunBatchReport,
+        RunBatchSender,
+        RunCycleService,
         RunReason,
         RunReport,
         RunSelectionResult,
@@ -39,12 +43,17 @@ else:
         sys.path.insert(0, str(_plugin_dir))
     from services import (
         AssetPipeline,
+        ChiShiService,
+        CommandGate,
+        CronScheduler,
         HistoryStore,
         PdfService,
         PushMessageService,
         ReportRenderer,
         RunBatch,
         RunBatchReport,
+        RunBatchSender,
+        RunCycleService,
         RunReason,
         RunReport,
         RunSelectionResult,
@@ -122,11 +131,7 @@ class ShitJournalDailyPlugin(Star):
     def __init__(self, context: Context, config: dict | None = None):
         super().__init__(context)
         self.config = config or {}
-        self._run_lock = asyncio.Lock()
         self._cron_job_ids: list[str] = []
-        self._chi_shi_cooldown_lock = asyncio.Lock()
-        self._chi_shi_group_cooldown_until_monotonic: dict[str, float] = {}
-        self._chi_shi_group_inflight: set[str] = set()
         self._temp_trim_lock = asyncio.Lock()
         self._next_temp_trim_monotonic = 0.0
         self._plugin_data_dir = Path(".")
@@ -153,6 +158,11 @@ class ShitJournalDailyPlugin(Star):
         self._run_selector = self._create_run_selector()
         self._asset_pipeline = self._create_asset_pipeline()
         self._report_renderer = self._create_report_renderer()
+        self._command_gate = self._create_command_gate()
+        self._run_batch_sender = self._create_run_batch_sender()
+        self._run_cycle_service = self._create_run_cycle_service()
+        self._cron_scheduler = self._create_cron_scheduler()
+        self._chi_shi_service = self._create_chi_shi_service()
 
     def _create_run_selector(self) -> RunSelector:
         return RunSelector(
@@ -198,6 +208,102 @@ class ShitJournalDailyPlugin(Star):
             mask_sensitive_text=mask_sensitive_text,
             detail_url_base=DETAIL_URL_BASE,
             detail_hide_domain=lambda: self._cfg_bool("detail_hide_domain", False),
+        )
+
+    def _create_command_gate(self) -> CommandGate:
+        return CommandGate(
+            context_getter=lambda: self.context,
+            cfg_bool_getter=self._cfg_bool,
+            logger=logger,
+        )
+
+    def _create_run_batch_sender(self) -> RunBatchSender:
+        return RunBatchSender(
+            context_getter=lambda: self.context,
+            cfg_int_getter=self._cfg_int,
+            history_store=self._history_store,
+            load_submission_payload=self._load_submission_payload,
+            prepare_pdf_assets=self._prepare_pdf_assets,
+            build_push_text=lambda payload, detail_url, zone: self._build_push_text(
+                payload,
+                detail_url,
+                zone=zone,
+            ),
+            build_meta_preview=lambda payload: self._asset_pipeline.build_meta_preview(payload),
+            send_session_push=lambda **kwargs: self._push_messages.send_session_push(**kwargs),
+            release_temp_files=lambda pdf_file, png_file: self._temp_files.release(pdf_file, png_file),
+            maybe_trim_temp_files=self._maybe_trim_temp_files,
+            logger=logger,
+            mask_sensitive_text=mask_sensitive_text,
+            max_send_concurrency=MAX_SEND_CONCURRENCY,
+            max_batch_send_concurrency=MAX_BATCH_SEND_CONCURRENCY,
+        )
+
+    def _create_run_cycle_service(self) -> RunCycleService:
+        return RunCycleService(
+            cfg_getter=self._cfg,
+            run_selector=self._run_selector,
+            history_store=self._history_store,
+            send_batches=lambda batches, send_semaphore=None: self._send_run_batches(
+                batches,
+                send_semaphore=send_semaphore,
+            ),
+            coerce_run_batch_report=lambda value: self._run_batch_sender.coerce_run_batch_report(value),
+            resolve_run_batch_reports=lambda batch_reports, sent_ok, sent_total: self._run_batch_sender.resolve_run_batch_reports(
+                batch_reports=batch_reports,
+                sent_ok=sent_ok,
+                sent_total=sent_total,
+            ),
+            get_primary_zone=self._get_primary_zone,
+            get_candidate_zones=self._get_candidate_zones,
+            get_configured_send_concurrency=self._get_configured_send_concurrency,
+            maybe_trim_temp_files=self._maybe_trim_temp_files,
+            logger=logger,
+            mask_sensitive_text=mask_sensitive_text,
+            run_fetch_page_size=RUN_FETCH_PAGE_SIZE,
+        )
+
+    def _create_cron_scheduler(self) -> CronScheduler:
+        return CronScheduler(
+            context_getter=lambda: self.context,
+            plugin_id_getter=lambda: getattr(self, "plugin_id", "shitjournal_daily"),
+            cfg_getter=self._cfg,
+            cfg_bool_getter=self._cfg_bool,
+            kv_getter=self.get_kv_data,
+            kv_putter=self.put_kv_data,
+            get_cron_job_ids=lambda: list(self._cron_job_ids),
+            set_cron_job_ids=self._set_cron_job_ids,
+            scheduled_handler=self._scheduled_tick,
+            run_cycle=lambda **kwargs: self._run_cycle(**kwargs),
+            render_report=lambda report, include_debug=False: self._report_renderer.render_report(
+                report,
+                include_debug=include_debug,
+            ),
+            logger=logger,
+            default_schedule_times=DEFAULT_SCHEDULE_TIMES,
+        )
+
+    def _create_chi_shi_service(self) -> ChiShiService:
+        return ChiShiService(
+            select_candidate_from_zones=lambda **kwargs: self._run_selector.select_chi_shi_candidate_from_zones(
+                **kwargs,
+            ),
+            load_submission_payload=self._load_submission_payload,
+            prepare_pdf_assets=self._prepare_pdf_assets,
+            build_push_text=lambda payload, detail_url, zone: self._build_push_text(
+                payload,
+                detail_url,
+                zone=zone,
+            ),
+            build_preprint_detail_url=self._build_preprint_detail_url,
+            send_event_push=lambda **kwargs: self._push_messages.send_event_push(**kwargs),
+            mark_chi_shi_paper_sent=self._mark_chi_shi_paper_sent,
+            get_primary_zone=self._get_primary_zone,
+            get_candidate_zones=self._get_candidate_zones,
+            build_zone_scope_text=self._build_zone_scope_text,
+            cfg_int_getter=self._cfg_int,
+            mask_sensitive_text=mask_sensitive_text,
+            fetch_page_size=CHI_SHI_FETCH_PAGE_SIZE,
         )
 
     async def initialize(self):
@@ -376,37 +482,11 @@ class ShitJournalDailyPlugin(Star):
         session_key: str,
         scope_label: str,
     ) -> tuple[list[str], bool, Path | None, Path | None]:
-        primary_zone = self._get_primary_zone()
-        zone_order = self._get_candidate_zones(primary_zone)
-        selected, saw_candidates, selection_warnings = await self._run_selector.select_chi_shi_candidate_from_zones(
-            zone_order=zone_order,
-            session_key=session_key,
-            fetch_page_size=CHI_SHI_FETCH_PAGE_SIZE,
-        )
-        if not selected:
-            apply_success_cooldown, reply_text = self._build_missing_chi_shi_selection_response(
-                zone_order=zone_order,
-                scope_label=scope_label,
-                saw_candidates=saw_candidates,
-                selection_warnings=selection_warnings,
-            )
-            return [reply_text], apply_success_cooldown, None, None
-        apply_success_cooldown, pdf_file, png_file = await self._push_chi_shi_selection(
+        return await self._chi_shi_service.execute_wo_yao_chi_shi(
             event=event,
             session_key=session_key,
-            selection=selected,
+            scope_label=scope_label,
         )
-        if not apply_success_cooldown:
-            return ["候选论文缺少 ID。"], False, None, None
-        if not selection_warnings:
-            return [], True, pdf_file, png_file
-        return [
-            self._build_chi_shi_success_text(
-                requested_zone=primary_zone,
-                selected_zone=selected.zone,
-                warnings=selection_warnings,
-            ),
-        ], True, pdf_file, png_file
 
     def _build_missing_chi_shi_selection_response(
         self,
@@ -416,15 +496,12 @@ class ShitJournalDailyPlugin(Star):
         saw_candidates: bool,
         selection_warnings: list[str],
     ) -> tuple[bool, str]:
-        if selection_warnings:
-            return False, self._build_chi_shi_failure_text(
-                saw_candidates=saw_candidates,
-                warnings=selection_warnings,
-                scope_label=scope_label,
-            )
-        if saw_candidates:
-            return True, f"{scope_label}{self._build_zone_scope_text(zone_order)}最近这些论文都推送过了，等下一篇。"
-        return False, "未找到最新论文。"
+        return self._chi_shi_service.build_missing_chi_shi_selection_response(
+            zone_order=zone_order,
+            scope_label=scope_label,
+            saw_candidates=saw_candidates,
+            selection_warnings=selection_warnings,
+        )
 
     async def _push_chi_shi_selection(
         self,
@@ -433,41 +510,14 @@ class ShitJournalDailyPlugin(Star):
         session_key: str,
         selection: Any,
     ) -> tuple[bool, Path | None, Path | None]:
-        zone = str(selection.zone).strip()
-        paper_id = str(selection.paper_id).strip()
-        candidate = dict(selection.candidate or {})
-        if not paper_id:
-            return False, None, None
-        payload = await self._load_submission_payload(candidate, paper_id)
-        detail_url = self._build_preprint_detail_url(paper_id)
-        pdf_file, png_file, pdf_url = await self._prepare_pdf_assets(payload, paper_id)
-        text = self._build_push_text(payload, detail_url, zone=zone)
-        await self._push_messages.send_event_push(
+        return await self._chi_shi_service.push_chi_shi_selection(
             event=event,
-            text=text,
-            png_file=png_file,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
+            session_key=session_key,
+            selection=selection,
         )
-        await self._history_store.mark_chi_shi_paper_sent(zone, session_key, paper_id)
-        return True, pdf_file, png_file
 
     async def _check_command_permission(self, event: AstrMessageEvent) -> bool:
-        if not self._looks_like_message_event(event):
-            logger.error(
-                "指令权限检查失败：无效事件类型=%s",
-                type(event).__name__,
-            )
-            return False
-
-        if not self._cfg_bool("command_admin_only", True):
-            return True
-        if self._is_admin_event(event):
-            return True
-        if self._cfg_bool("command_no_permission_reply", True):
-            await event.send(event.plain_result("权限不足：仅管理员可使用该指令。"))
-        event.stop_event()
-        return False
+        return await self._command_gate.check_command_permission(event)
 
     # 命令兼容层：处理 AstrBot 在不同注入路径下 event/action 参数位置不一致的情况。
     def _normalize_command_event(
@@ -477,77 +527,21 @@ class ShitJournalDailyPlugin(Star):
         kwargs: dict[str, Any],
         command_name: str,
     ) -> tuple[AstrMessageEvent, tuple[Any, ...], dict[str, Any]] | None:
-        if self._looks_like_message_event(event):
-            return event, args, kwargs
-
-        candidate = kwargs.get("event")
-        if self._looks_like_message_event(candidate):
-            cleaned_kwargs = dict(kwargs)
-            cleaned_kwargs.pop("event", None)
-            logger.warning(
-                "指令 %s 从 kwargs 中修正了偏移的事件对象（原类型=%s）。",
-                command_name,
-                type(event).__name__,
-            )
-            return candidate, args, cleaned_kwargs
-
-        for idx, item in enumerate(args):
-            if self._looks_like_message_event(item):
-                shifted_args = args[:idx] + args[idx + 1 :]
-                logger.warning(
-                    "指令 %s 从 args[%d] 中修正了偏移的事件对象（原类型=%s）。",
-                    command_name,
-                    idx,
-                    type(event).__name__,
-                )
-                return item, shifted_args, kwargs
-
-        logger.error(
-            "指令 %s 事件归一化失败：event_type=%s args_types=%s kwargs_keys=%s",
-            command_name,
-            type(event).__name__,
-            [type(item).__name__ for item in args[:4]],
-            list(kwargs.keys())[:8],
+        return self._command_gate.normalize_command_event(
+            event=event,
+            args=args,
+            kwargs=kwargs,
+            command_name=command_name,
         )
-        return None
 
     def _looks_like_message_event(self, value: Any) -> bool:
-        if isinstance(value, AstrMessageEvent):
-            return True
-        return (
-            value is not None
-            and hasattr(value, "plain_result")
-            and hasattr(value, "send")
-            and hasattr(value, "stop_event")
-            and hasattr(value, "unified_msg_origin")
-            and callable(getattr(value, "get_sender_id", None))
-        )
+        return self._command_gate.looks_like_message_event(value)
 
     def _is_admin_event(self, event: AstrMessageEvent) -> bool:
-        is_admin = getattr(event, "is_admin", None)
-        if callable(is_admin) and is_admin():
-            return True
-        return self._is_sender_in_admins(event)
+        return self._command_gate.is_admin_event(event)
 
     def _is_sender_in_admins(self, event: AstrMessageEvent) -> bool:
-        sender_id = str(event.get_sender_id()).strip()
-        if not sender_id:
-            return False
-
-        config_obj: Any = getattr(self.context, "astrbot_config", None)
-        if not isinstance(config_obj, dict):
-            return False
-
-        admins_raw = config_obj.get("admins_id", [])
-        if isinstance(admins_raw, str):
-            normalized_admins = [part.strip() for part in admins_raw.split(",")]
-        elif isinstance(admins_raw, (list, tuple, set)):
-            normalized_admins = [str(part).strip() for part in admins_raw]
-        else:
-            normalized_admins = []
-
-        admins = {item for item in normalized_admins if item}
-        return sender_id in admins
+        return self._command_gate.is_sender_in_admins(event)
 
     def _get_chi_shi_session_scope_text(self, event: AstrMessageEvent) -> str:
         if event.get_group_id():
@@ -563,19 +557,11 @@ class ShitJournalDailyPlugin(Star):
         scope_label: str,
         ignore_cooldown: bool,
     ) -> tuple[bool, str]:
-        async with self._chi_shi_cooldown_lock:
-            if session_key in self._chi_shi_group_inflight:
-                return False, f"{scope_label}已有赤石任务在执行，请稍后再试。"
-
-            if not ignore_cooldown:
-                now = time.monotonic()
-                cooldown_until = float(self._chi_shi_group_cooldown_until_monotonic.get(session_key, 0.0))
-                remaining = cooldown_until - now
-                if remaining > 0:
-                    return False, f"{scope_label}冷却中，请 {int(remaining + 0.999)} 秒后再试。"
-
-            self._chi_shi_group_inflight.add(session_key)
-            return True, ""
+        return await self._chi_shi_service.try_enter_chi_shi_cooldown(
+            session_key=session_key,
+            scope_label=scope_label,
+            ignore_cooldown=ignore_cooldown,
+        )
 
     async def _leave_chi_shi_cooldown(
         self,
@@ -583,111 +569,32 @@ class ShitJournalDailyPlugin(Star):
         apply_success_cooldown: bool,
         ignore_cooldown: bool,
     ) -> None:
-        async with self._chi_shi_cooldown_lock:
-            self._chi_shi_group_inflight.discard(session_key)
-            if ignore_cooldown:
-                return
-            cooldown_sec = self._cfg_int("chi_shi_group_cooldown_sec", 60, min_value=0)
-            fail_cooldown_sec = self._cfg_int("chi_shi_group_fail_cooldown_sec", 10, min_value=0)
-            effective_cooldown = cooldown_sec if apply_success_cooldown else fail_cooldown_sec
-            if effective_cooldown > 0:
-                self._chi_shi_group_cooldown_until_monotonic[session_key] = (
-                    time.monotonic() + effective_cooldown
-                )
-            else:
-                self._chi_shi_group_cooldown_until_monotonic.pop(session_key, None)
+        await self._chi_shi_service.leave_chi_shi_cooldown(
+            session_key=session_key,
+            apply_success_cooldown=apply_success_cooldown,
+            ignore_cooldown=ignore_cooldown,
+        )
 
     async def _register_cron_jobs(self) -> None:
-        cron_manager = getattr(self.context, "cron_manager", None)
-        if cron_manager is None:
-            logger.error("cron_manager 不可用，已跳过定时任务注册。")
-            return
-
-        timezone = str(self._cfg("timezone", "Asia/Shanghai")).strip() or "Asia/Shanghai"
-        times = self._resolve_schedule_times()
-        plugin_id = getattr(self, "plugin_id", "shitjournal_daily")
-        created_job_ids: list[str] = []
-        try:
-            for idx, time_text in enumerate(times):
-                parsed = self._parse_hhmm(time_text)
-                if parsed is None:
-                    logger.warning("已跳过无效的定时时间：%s", time_text)
-                    continue
-                hour, minute = parsed
-                cron_expression = f"{minute} {hour} * * *"
-                job = await cron_manager.add_basic_job(
-                    name=f"{plugin_id}_shitjournal_{idx}",
-                    cron_expression=cron_expression,
-                    handler=self._scheduled_tick,
-                    description=f"shitjournal 定时推送 {time_text}",
-                    timezone=timezone,
-                    payload={"schedule_time": time_text},
-                    enabled=True,
-                    persistent=False,
-                )
-                created_job_ids.append(job.job_id)
-                logger.info(
-                    "已注册定时任务：任务ID=%s 时间=%s 表达式=%s 时区=%s",
-                    job.job_id,
-                    time_text,
-                    cron_expression,
-                    timezone,
-                )
-        except Exception:
-            failed_ids = await self._delete_cron_jobs(cron_manager, created_job_ids)
-            self._cron_job_ids = failed_ids
-            await self.put_kv_data("cron_job_ids", failed_ids)
-            raise
-
-        self._cron_job_ids = created_job_ids
-        await self.put_kv_data("cron_job_ids", created_job_ids)
+        await self._cron_scheduler.register_cron_jobs()
 
     async def _clear_cron_jobs(self) -> None:
-        ids = await self._load_cron_job_ids()
-        cron_manager = getattr(self.context, "cron_manager", None)
-        if cron_manager is None:
-            self._cron_job_ids = ids
-            await self.put_kv_data("cron_job_ids", ids)
-            return
-
-        failed_ids = await self._delete_cron_jobs(cron_manager, ids)
-        self._cron_job_ids = failed_ids
-        await self.put_kv_data("cron_job_ids", failed_ids)
+        await self._cron_scheduler.clear_cron_jobs()
 
     async def _load_cron_job_ids(self) -> list[str]:
-        ids = [str(job_id).strip() for job_id in self._cron_job_ids if str(job_id).strip()]
-        if ids:
-            return ids
-        loaded = await self.get_kv_data("cron_job_ids", [])
-        if not isinstance(loaded, list):
-            return []
-        return [str(job_id).strip() for job_id in loaded if str(job_id).strip()]
+        return await self._cron_scheduler.load_cron_job_ids()
 
     async def _delete_cron_jobs(self, cron_manager: Any, ids: list[str]) -> list[str]:
-        failed_ids: list[str] = []
-        for job_id in ids:
-            try:
-                await cron_manager.delete_job(job_id)
-                logger.info("已删除旧定时任务：%s", job_id)
-            except Exception:
-                failed_ids.append(job_id)
-                logger.warning("删除定时任务失败，已忽略：%s", job_id, exc_info=True)
-        return failed_ids
+        return await self._cron_scheduler.delete_cron_jobs(cron_manager, ids)
 
     def _resolve_schedule_times(self) -> list[str]:
-        marker = object()
-        raw = self._cfg("schedule_times", marker)
-        if raw is marker:
-            return DEFAULT_SCHEDULE_TIMES.copy()
-        return self._normalize_schedule_times(raw)
+        return self._cron_scheduler.resolve_schedule_times()
+
+    def _set_cron_job_ids(self, ids: list[str]) -> None:
+        self._cron_job_ids = [str(job_id).strip() for job_id in ids if str(job_id).strip()]
 
     async def _scheduled_tick(self, schedule_time: str = "") -> None:
-        report = await self._run_cycle(
-            force=False,
-            source=f"定时:{schedule_time or '未知'}",
-            latest_only=self._cfg_bool("schedule_latest_only", False),
-        )
-        logger.info("定时推送执行完成：%s", self._report_renderer.render_report(report, include_debug=True))
+        await self._cron_scheduler.scheduled_tick(schedule_time=schedule_time)
 
     async def _run_cycle(
         self,
@@ -696,14 +603,11 @@ class ShitJournalDailyPlugin(Star):
         source: str,
         latest_only: bool = False,
     ) -> RunReport:
-        if self._run_lock.locked():
-            return self._build_run_in_progress_report(source=source, latest_only=latest_only)
-        async with self._run_lock:
-            return await self._run_cycle_locked(
-                force=force,
-                source=source,
-                latest_only=latest_only,
-            )
+        return await self._run_cycle_service.run_cycle(
+            force=force,
+            source=source,
+            latest_only=latest_only,
+        )
 
     async def _run_cycle_locked(
         self,
@@ -712,37 +616,15 @@ class ShitJournalDailyPlugin(Star):
         source: str,
         latest_only: bool,
     ) -> RunReport:
-        primary_zone = self._get_primary_zone()
-        zone_order = self._get_candidate_zones(primary_zone)
-        report = self._build_run_cycle_report(source=source, primary_zone=primary_zone, force=force, latest_only=latest_only)
-        logger.info("开始执行推送：来源=%s 主分区=%s 分区顺序=%s 强制=%s 仅最新=%s", source, primary_zone, zone_order, force, latest_only)
-        try:
-            targets = await self._history_store.get_all_target_sessions(self._cfg("target_sessions", []))
-            if not targets:
-                report.reason_code = RunReason.NO_TARGET_SESSION_CONFIGURED
-                return report
-            previous_last_seen, selection = await self._select_run_cycle_batches(report=report, zone_order=zone_order, targets=targets, force=force, latest_only=latest_only)
-            if selection is None:
-                return report
-            if not selection.batches:
-                return await self._finalize_empty_run_selection(report=report, selection=selection, previous_last_seen=previous_last_seen)
-            batch_reports = await self._deliver_selected_run_batches(batches=selection.batches)
-            self._apply_run_batch_reports_to_report(report=report, batch_reports=batch_reports, primary_zone=primary_zone)
-            await self._persist_last_seen_map_if_changed(previous_last_seen=previous_last_seen, next_last_seen_map=selection.last_seen_map)
-            report.status, report.reason_code = self._resolve_run_batch_reports(batch_reports=batch_reports, sent_ok=report.sent_ok, sent_total=report.sent_total)
-            return report
-        finally:
-            try:
-                await self._maybe_trim_temp_files()
-            except Exception:
-                logger.warning("执行推送后清理临时文件失败。", exc_info=True)
+        return await self._run_cycle_service.run_cycle(
+            force=force,
+            source=source,
+            latest_only=latest_only,
+        )
 
     def _build_run_in_progress_report(self, *, source: str, latest_only: bool) -> RunReport:
-        return RunReport(
-            status=RunStatus.SKIPPED,
-            reason_code=RunReason.RUN_IN_PROGRESS,
+        return self._run_cycle_service._build_run_in_progress_report(
             source=source,
-            debug_reason="",
             latest_only=latest_only,
         )
 
@@ -754,11 +636,9 @@ class ShitJournalDailyPlugin(Star):
         force: bool,
         latest_only: bool,
     ) -> RunReport:
-        return RunReport(
-            status=RunStatus.FAILED,
+        return self._run_cycle_service._build_run_cycle_report(
             source=source,
-            zone=primary_zone,
-            requested_zone=primary_zone,
+            primary_zone=primary_zone,
             force=force,
             latest_only=latest_only,
         )
@@ -772,32 +652,13 @@ class ShitJournalDailyPlugin(Star):
         force: bool,
         latest_only: bool,
     ) -> tuple[dict[str, str], RunSelectionResult | None]:
-        previous_last_seen = await self._history_store.get_last_seen_map()
-        try:
-            selection = await self._run_selector.select_run_batches(
-                zone_order=zone_order,
-                targets=targets,
-                last_seen_map=previous_last_seen,
-                force=force,
-                latest_only=latest_only,
-                fetch_page_size=RUN_FETCH_PAGE_SIZE,
-            )
-        except RunSelectionError as exc:
-            self._apply_run_selection_error(
-                report=report,
-                reason_code=self._coerce_run_reason(exc.reason_code),
-                message=str(exc).strip(),
-            )
-            return previous_last_seen, None
-        except RuntimeError as exc:
-            self._apply_run_selection_error(
-                report=report,
-                reason_code=RunReason.FETCH_LATEST_FAILED,
-                message=str(exc).strip(),
-            )
-            return previous_last_seen, None
-        report.warnings = selection.warnings
-        return previous_last_seen, selection
+        return await self._run_cycle_service._select_run_cycle_batches(
+            report=report,
+            zone_order=zone_order,
+            targets=targets,
+            force=force,
+            latest_only=latest_only,
+        )
 
     def _apply_run_selection_error(
         self,
@@ -806,9 +667,7 @@ class ShitJournalDailyPlugin(Star):
         reason_code: RunReason,
         message: str,
     ) -> None:
-        report.reason_code = reason_code
-        logger.error("获取最新论文失败：%s", mask_sensitive_text(message), exc_info=True)
-        report.debug_reason = mask_sensitive_text(message)
+        self._run_cycle_service._apply_run_selection_error(report, reason_code, message)
 
     async def _finalize_empty_run_selection(
         self,
@@ -817,31 +676,18 @@ class ShitJournalDailyPlugin(Star):
         selection: RunSelectionResult,
         previous_last_seen: dict[str, str],
     ) -> RunReport:
-        if selection.warnings:
-            report.status = RunStatus.FAILED
-            report.reason_code = RunReason.FETCH_LATEST_FAILED
-            report.debug_reason = self._join_warning_text(selection.warnings)
-        else:
-            report.status = RunStatus.SKIPPED
-            report.reason_code = (
-                RunReason.ALREADY_DELIVERED if selection.saw_submission else RunReason.LATEST_NOT_FOUND
-            )
-        await self._persist_last_seen_map_if_changed(
+        return await self._run_cycle_service._finalize_empty_run_selection(
+            report=report,
+            selection=selection,
             previous_last_seen=previous_last_seen,
-            next_last_seen_map=selection.last_seen_map,
         )
-        return report
 
     async def _deliver_selected_run_batches(
         self,
         *,
         batches: list[RunBatch],
     ) -> list[RunBatchReport]:
-        raw_batch_reports = await self._send_run_batches(
-            batches,
-            send_semaphore=asyncio.Semaphore(self._get_configured_send_concurrency()),
-        )
-        return [self._coerce_run_batch_report(item) for item in raw_batch_reports]
+        return await self._run_cycle_service._deliver_selected_run_batches(batches)
 
     def _apply_run_batch_reports_to_report(
         self,
@@ -850,17 +696,11 @@ class ShitJournalDailyPlugin(Star):
         batch_reports: list[RunBatchReport],
         primary_zone: str,
     ) -> None:
-        report.batches = batch_reports
-        report.sent_ok = sum(batch.sent_ok for batch in batch_reports)
-        report.sent_total = sum(batch.sent_total for batch in batch_reports)
-        if batch_reports:
-            first_batch = batch_reports[0]
-            report.zone = first_batch.zone or primary_zone
-            report.paper_id = first_batch.paper_id
-            report.detail_url = first_batch.detail_url
-        first_debug_reason = self._pick_first_batch_debug_reason(batch_reports)
-        if first_debug_reason:
-            report.debug_reason = first_debug_reason
+        self._run_cycle_service._apply_run_batch_reports_to_report(
+            report,
+            batch_reports,
+            primary_zone,
+        )
 
     async def _persist_last_seen_map_if_changed(
         self,
@@ -868,9 +708,10 @@ class ShitJournalDailyPlugin(Star):
         previous_last_seen: dict[str, str],
         next_last_seen_map: dict[str, str],
     ) -> None:
-        if previous_last_seen == next_last_seen_map:
-            return
-        await self._history_store.set_last_seen_map(next_last_seen_map)
+        await self._run_cycle_service._persist_last_seen_map_if_changed(
+            previous_last_seen,
+            next_last_seen_map,
+        )
 
     async def _send_run_batches(
         self,
@@ -878,17 +719,10 @@ class ShitJournalDailyPlugin(Star):
         *,
         send_semaphore: asyncio.Semaphore | None = None,
     ) -> list[RunBatchReport | dict[str, Any]]:
-        if not batches:
-            return []
-        semaphore = asyncio.Semaphore(self._resolve_batch_send_concurrency(len(batches)))
-
-        async def _send_one(batch: RunBatch) -> RunBatchReport:
-            async with semaphore:
-                if send_semaphore is None:
-                    return await self._send_run_batch(batch)
-                return await self._send_run_batch(batch, send_semaphore=send_semaphore)
-
-        return await asyncio.gather(*[_send_one(batch) for batch in batches])
+        return await self._run_batch_sender.send_run_batches(
+            batches,
+            send_semaphore=send_semaphore,
+        )
 
     async def _send_run_batch(
         self,
@@ -896,10 +730,10 @@ class ShitJournalDailyPlugin(Star):
         *,
         send_semaphore: asyncio.Semaphore | None = None,
     ) -> RunBatchReport:
-        try:
-            return await self._send_run_batch_inner(batch=batch, send_semaphore=send_semaphore)
-        finally:
-            pass
+        return await self._run_batch_sender.send_run_batch(
+            batch,
+            send_semaphore=send_semaphore,
+        )
 
     async def _send_run_batch_inner(
         self,
@@ -907,52 +741,10 @@ class ShitJournalDailyPlugin(Star):
         batch: RunBatch,
         send_semaphore: asyncio.Semaphore | None,
     ) -> RunBatchReport:
-        zone, latest, paper_id, detail_url, targets = self._unpack_run_batch(batch)
-        report = self._build_run_batch_report(
-            zone=zone,
-            paper_id=paper_id,
-            detail_url=detail_url,
-            sent_total=len(targets),
+        return await self._run_batch_sender.send_run_batch_inner(
+            batch=batch,
+            send_semaphore=send_semaphore,
         )
-        pdf_file: Path | None = None
-        png_file: Path | None = None
-        try:
-            payload, pdf_file, png_file, pdf_url, text = await self._prepare_run_batch_delivery(
-                latest=latest,
-                paper_id=paper_id,
-                detail_url=detail_url,
-                zone=zone,
-            )
-            sent_ok, sent_success_targets = await self._send_push_to_targets(
-                targets=targets,
-                text=text,
-                png_file=png_file,
-                pdf_file=pdf_file,
-                pdf_url=pdf_url,
-                send_semaphore=send_semaphore,
-            )
-            report.sent_ok = sent_ok
-            await self._persist_run_batch_success_targets(
-                zone=zone,
-                paper_id=paper_id,
-                success_targets=sent_success_targets,
-            )
-            report.status = self._resolve_send_status(sent_ok=sent_ok, sent_total=len(targets))
-            report.reason_code = self._resolve_send_reason_code(report.status)
-            return report
-        except Exception as exc:
-            return self._build_run_batch_exception_report(
-                report=report,
-                zone=zone,
-                paper_id=paper_id,
-                error=exc,
-            )
-        finally:
-            await self._temp_files.release(pdf_file, png_file)
-            try:
-                await self._maybe_trim_temp_files()
-            except Exception:
-                logger.warning("批次推送后清理临时文件失败。", exc_info=True)
 
     def _unpack_run_batch(
         self,
@@ -974,14 +766,12 @@ class ShitJournalDailyPlugin(Star):
         detail_url: str,
         zone: str,
     ) -> tuple[dict[str, Any], Path | None, Path | None, str, str]:
-        payload = await self._load_submission_payload(latest, paper_id)
-        logger.info(
-            "论文元数据：%s",
-            json.dumps(self._asset_pipeline.build_meta_preview(payload), ensure_ascii=False),
+        return await self._run_batch_sender.prepare_run_batch_delivery(
+            latest=latest,
+            paper_id=paper_id,
+            detail_url=detail_url,
+            zone=zone,
         )
-        pdf_file, png_file, pdf_url = await self._prepare_pdf_assets(payload, paper_id)
-        text = self._build_push_text(payload, detail_url, zone=zone)
-        return payload, pdf_file, png_file, pdf_url, text
 
     async def _persist_run_batch_success_targets(
         self,
@@ -990,9 +780,7 @@ class ShitJournalDailyPlugin(Star):
         paper_id: str,
         success_targets: list[str],
     ) -> None:
-        if not success_targets:
-            return
-        await self._history_store.mark_run_targets_delivered(
+        await self._run_batch_sender.persist_run_batch_success_targets(
             zone=zone,
             paper_id=paper_id,
             success_targets=success_targets,
@@ -1006,30 +794,11 @@ class ShitJournalDailyPlugin(Star):
         paper_id: str,
         error: Exception,
     ) -> RunBatchReport:
-        if report.sent_ok > 0:
-            logger.error(
-                "写入推送去重状态失败：分区=%s 论文ID=%s 错误=%s",
-                zone,
-                paper_id,
-                mask_sensitive_text(str(error)),
-                exc_info=True,
-            )
-            return self._build_failed_run_batch_report(
-                report=report,
-                reason_code=RunReason.DELIVERY_STATE_WRITE_FAILED,
-                debug_reason=str(error),
-            )
-        logger.error(
-            "批次推送失败：分区=%s 论文ID=%s 错误=%s",
-            zone,
-            paper_id,
-            mask_sensitive_text(str(error)),
-            exc_info=True,
-        )
-        return self._build_failed_run_batch_report(
+        return self._run_batch_sender.build_run_batch_exception_report(
             report=report,
-            reason_code=RunReason.ALL_SENDS_FAILED,
-            debug_reason=str(error),
+            zone=zone,
+            paper_id=paper_id,
+            error=error,
         )
 
     def _build_run_batch_report(
@@ -1040,15 +809,11 @@ class ShitJournalDailyPlugin(Star):
         detail_url: str,
         sent_total: int,
     ) -> RunBatchReport:
-        return RunBatchReport(
-            status=RunStatus.FAILED,
-            reason_code=RunReason.UNKNOWN,
+        return self._run_batch_sender.build_run_batch_report(
             zone=zone,
             paper_id=paper_id,
             detail_url=detail_url,
-            sent_ok=0,
             sent_total=sent_total,
-            debug_reason="",
         )
 
     def _build_failed_run_batch_report(
@@ -1058,17 +823,17 @@ class ShitJournalDailyPlugin(Star):
         reason_code: RunReason | str,
         debug_reason: str,
     ) -> RunBatchReport:
-        report.status = RunStatus.FAILED
-        report.reason_code = self._coerce_run_reason(reason_code)
-        report.debug_reason = mask_sensitive_text(debug_reason)
-        return report
+        return self._run_batch_sender.build_failed_run_batch_report(
+            report=report,
+            reason_code=reason_code,
+            debug_reason=debug_reason,
+        )
 
     def _resolve_send_status(self, *, sent_ok: int, sent_total: int) -> RunStatus:
-        if sent_total > 0 and sent_ok == sent_total:
-            return RunStatus.SUCCESS
-        if sent_ok > 0:
-            return RunStatus.PARTIAL
-        return RunStatus.FAILED
+        return self._run_batch_sender.resolve_send_status(
+            sent_ok=sent_ok,
+            sent_total=sent_total,
+        )
 
     def _resolve_run_batch_reports(
         self,
@@ -1077,44 +842,26 @@ class ShitJournalDailyPlugin(Star):
         sent_ok: int,
         sent_total: int,
     ) -> tuple[RunStatus, RunReason]:
-        if any(batch.reason_code == RunReason.DELIVERY_STATE_WRITE_FAILED for batch in batch_reports):
-            return RunStatus.FAILED, RunReason.DELIVERY_STATE_WRITE_FAILED
-        status = self._resolve_send_status(sent_ok=sent_ok, sent_total=sent_total)
-        return status, self._resolve_send_reason_code(status)
+        return self._run_batch_sender.resolve_run_batch_reports(
+            batch_reports=batch_reports,
+            sent_ok=sent_ok,
+            sent_total=sent_total,
+        )
 
     def _resolve_send_reason_code(self, status: RunStatus | str) -> RunReason:
-        normalized = self._coerce_run_status(status)
-        if normalized == RunStatus.SUCCESS:
-            return RunReason.PUSHED_SUCCESSFULLY
-        if normalized == RunStatus.PARTIAL:
-            return RunReason.PUSHED_PARTIALLY
-        return RunReason.ALL_SENDS_FAILED
+        return self._run_batch_sender.resolve_send_reason_code(status)
 
     def _coerce_run_status(self, value: RunStatus | str) -> RunStatus:
-        if isinstance(value, RunStatus):
-            return value
-        text = str(value).strip().lower()
-        try:
-            return RunStatus(text)
-        except ValueError:
-            return RunStatus.UNKNOWN
+        return self._run_batch_sender.coerce_run_status(value)
 
     def _coerce_run_reason(self, value: RunReason | str) -> RunReason:
-        if isinstance(value, RunReason):
-            return value
-        text = str(value).strip()
-        try:
-            return RunReason(text)
-        except ValueError:
-            return RunReason.UNKNOWN
+        return self._run_batch_sender.coerce_run_reason(value)
 
     def _coerce_run_batch_report(self, value: RunBatchReport | dict[str, Any]) -> RunBatchReport:
-        if isinstance(value, RunBatchReport):
-            return value
-        return RunBatchReport.from_dict(value)
+        return self._run_batch_sender.coerce_run_batch_report(value)
 
     def _resolve_batch_send_concurrency(self, batch_count: int) -> int:
-        return min(MAX_BATCH_SEND_CONCURRENCY, self._get_configured_send_concurrency(), batch_count)
+        return self._run_batch_sender.resolve_batch_send_concurrency(batch_count)
 
     def _get_configured_send_concurrency(self) -> int:
         raw_concurrency = getattr(self, "_send_concurrency", 3)
@@ -1125,11 +872,7 @@ class ShitJournalDailyPlugin(Star):
         return min(MAX_SEND_CONCURRENCY, max(1, configured_concurrency))
 
     def _pick_first_batch_debug_reason(self, batch_reports: list[RunBatchReport]) -> str:
-        for batch_report in batch_reports:
-            debug_reason = mask_sensitive_text(str(batch_report.debug_reason).strip())
-            if debug_reason:
-                return debug_reason
-        return ""
+        return self._run_cycle_service._pick_first_debug_reason(batch_reports)
 
     async def _load_submission_payload(
         self,
@@ -1141,6 +884,9 @@ class ShitJournalDailyPlugin(Star):
     async def _prepare_pdf_assets(self, payload: dict[str, Any], paper_id: str) -> tuple[Path, Path, str]:
         return await self._asset_pipeline.prepare_pdf_assets(payload, paper_id)
 
+    async def _mark_chi_shi_paper_sent(self, zone: str, session_key: str, paper_id: str) -> None:
+        await self._history_store.mark_chi_shi_paper_sent(zone, session_key, paper_id)
+
     async def _send_push_to_targets(
         self,
         targets: list[str],
@@ -1151,42 +897,14 @@ class ShitJournalDailyPlugin(Star):
         *,
         send_semaphore: asyncio.Semaphore | None = None,
     ) -> tuple[int, list[str]]:
-        semaphore = send_semaphore or asyncio.Semaphore(self._get_configured_send_concurrency())
-
-        async def _send_one(session: str) -> tuple[str, bool]:
-            ok = False
-            async with semaphore:
-                try:
-                    ok = await self._push_messages.send_session_push(
-                        context=self.context,
-                        session=session,
-                        text=text,
-                        png_file=png_file,
-                        pdf_file=pdf_file,
-                        pdf_url=pdf_url,
-                    )
-                except Exception:
-                    logger.error("发送消息失败：会话=%s", session, exc_info=True)
-            logger.info("发送消息结果：会话=%s 是否成功=%s", session, ok)
-            return session, ok
-
-        results = await asyncio.gather(
-            *[_send_one(session) for session in targets],
-            return_exceptions=True,
+        return await self._run_batch_sender.send_push_to_targets(
+            targets=targets,
+            text=text,
+            png_file=png_file,
+            pdf_file=pdf_file,
+            pdf_url=pdf_url,
+            send_semaphore=send_semaphore,
         )
-        ok_results: list[tuple[str, bool]] = []
-        for result in results:
-            if isinstance(result, BaseException):
-                logger.error(
-                    "发送任务出现未预期异常",
-                    exc_info=(type(result), result, result.__traceback__),
-                )
-                continue
-            ok_results.append(result)
-
-        success_targets = [session for session, ok in ok_results if ok]
-        sent_ok = len(success_targets)
-        return sent_ok, success_targets
 
     def _build_push_text(
         self,
@@ -1226,71 +944,21 @@ class ShitJournalDailyPlugin(Star):
         kwargs: dict[str, Any],
         default_action: str,
     ) -> tuple[str, str]:
-        positional_action: Any = args[0] if len(args) >= 1 else None
-        positional_arg: Any = args[1] if len(args) >= 2 else None
-        positional_extra: Any = list(args[2:]) if len(args) >= 3 else None
-        default_action_normalized = default_action.strip().lower()
-
-        action_tokens = self._pick_command_tokens(
+        return self._command_gate.parse_command_action_arg(
+            args=args,
             kwargs=kwargs,
-            primary_key="action",
-            alias_key="_action",
-            positional_value=positional_action,
+            default_action=default_action,
         )
-        arg_tokens = self._pick_command_tokens(
-            kwargs=kwargs,
-            primary_key="arg",
-            alias_key="_arg",
-            positional_value=positional_arg,
-        )
-        extra_tokens = self._pick_command_tokens(
-            kwargs=kwargs,
-            primary_key="extra_args",
-            alias_key="_extra_args",
-            positional_value=positional_extra,
-        )
-
-        action = action_tokens[0] if action_tokens else default_action_normalized
-        action = action or default_action_normalized
-        merged_arg_tokens = action_tokens[1:] + arg_tokens + extra_tokens
-        if action == default_action_normalized and merged_arg_tokens:
-            action = merged_arg_tokens.pop(0)
-        arg_text = " ".join(merged_arg_tokens).strip()
-        return action, arg_text
 
     def _parse_action_arg_from_message(
         self,
         event: AstrMessageEvent,
         command_name: str,
     ) -> tuple[str, str]:
-        message_text = ""
-        getter = getattr(event, "get_message_str", None)
-        if callable(getter):
-            message_text = str(getter() or "")
-        if not message_text:
-            message_text = str(getattr(event, "message_str", "") or "")
-
-        text = re.sub(r"\s+", " ", message_text).strip().lower()
-        if not text:
-            return "", ""
-
-        command = command_name.strip().lower()
-        if not command:
-            return "", ""
-
-        for candidate in (command, f"/{command}"):
-            if text == candidate:
-                return "help", ""
-            if text.startswith(f"{candidate} "):
-                tail = text[len(candidate) :].strip()
-                if not tail:
-                    return "help", ""
-                tokens = [part for part in tail.split(" ") if part]
-                action = tokens[0] if tokens else "help"
-                arg = " ".join(tokens[1:]).strip() if len(tokens) >= 2 else ""
-                return action, arg
-
-        return "", ""
+        return self._command_gate.parse_action_arg_from_message(
+            event=event,
+            command_name=command_name,
+        )
 
     def _pick_command_tokens(
         self,
@@ -1416,35 +1084,10 @@ class ShitJournalDailyPlugin(Star):
         return "目标分区"
 
     def _parse_hhmm(self, value: str) -> tuple[int, int] | None:
-        text = str(value).strip()
-        match = re.match(r"^([01]?\d|2[0-3]):([0-5]\d)$", text)
-        if not match:
-            return None
-        hour = int(match.group(1))
-        minute = int(match.group(2))
-        return hour, minute
+        return self._cron_scheduler.parse_hhmm(value)
 
     def _normalize_schedule_times(self, raw: Any) -> list[str]:
-        values: list[str] = []
-        if isinstance(raw, str):
-            values = [item.strip() for item in re.split(r"[,\s]+", raw) if item.strip()]
-        elif isinstance(raw, list):
-            values = [str(item).strip() for item in raw if str(item).strip()]
-        else:
-            values = []
-
-        normalized: list[str] = []
-        seen = set()
-        for value in values:
-            parsed = self._parse_hhmm(value)
-            if parsed is None:
-                continue
-            formatted = f"{parsed[0]:02d}:{parsed[1]:02d}"
-            if formatted in seen:
-                continue
-            seen.add(formatted)
-            normalized.append(formatted)
-        return normalized
+        return self._cron_scheduler.normalize_schedule_times(raw)
 
     def _normalize_session_list(self, raw: Any) -> list[str]:
         if not isinstance(raw, list):
@@ -1510,11 +1153,11 @@ class ShitJournalDailyPlugin(Star):
         selected_zone: str,
         warnings: list[str],
     ) -> str:
-        lines = ["已继续回退并完成推送。"]
-        if requested_zone and requested_zone != selected_zone:
-            lines.append(f"最终分区: {selected_zone}")
-        self._append_warning_lines(lines, warnings)
-        return "\n".join(lines)
+        return self._chi_shi_service.build_chi_shi_success_text(
+            requested_zone=requested_zone,
+            selected_zone=selected_zone,
+            warnings=warnings,
+        )
 
     def _build_chi_shi_failure_text(
         self,
@@ -1523,9 +1166,8 @@ class ShitJournalDailyPlugin(Star):
         warnings: list[str],
         scope_label: str,
     ) -> str:
-        if saw_candidates:
-            lines = [f"抓取失败：回退过程中存在分区抓取失败，无法确认{scope_label}是否都已推送。"]
-        else:
-            lines = ["抓取失败：已尝试所有可回退分区，但未能成功获取可推送论文。"]
-        self._append_warning_lines(lines, warnings)
-        return "\n".join(lines)
+        return self._chi_shi_service.build_chi_shi_failure_text(
+            saw_candidates=saw_candidates,
+            warnings=warnings,
+            scope_label=scope_label,
+        )

--- a/main.py
+++ b/main.py
@@ -496,61 +496,82 @@ class ShitJournalDailyPlugin(Star):
             return
 
         timezone = str(self._cfg("timezone", "Asia/Shanghai")).strip() or "Asia/Shanghai"
-        times = self._normalize_schedule_times(self._cfg("schedule_times", DEFAULT_SCHEDULE_TIMES))
+        times = self._resolve_schedule_times()
         plugin_id = getattr(self, "plugin_id", "shitjournal_daily")
         created_job_ids: list[str] = []
-
-        for idx, time_text in enumerate(times):
-            parsed = self._parse_hhmm(time_text)
-            if parsed is None:
-                logger.warning("已跳过无效的定时时间：%s", time_text)
-                continue
-            hour, minute = parsed
-            cron_expression = f"{minute} {hour} * * *"
-            job = await cron_manager.add_basic_job(
-                name=f"{plugin_id}_shitjournal_{idx}",
-                cron_expression=cron_expression,
-                handler=self._scheduled_tick,
-                description=f"shitjournal 定时推送 {time_text}",
-                timezone=timezone,
-                payload={"schedule_time": time_text},
-                enabled=True,
-                persistent=False,
-            )
-            created_job_ids.append(job.job_id)
-            logger.info(
-                "已注册定时任务：任务ID=%s 时间=%s 表达式=%s 时区=%s",
-                job.job_id,
-                time_text,
-                cron_expression,
-                timezone,
-            )
+        try:
+            for idx, time_text in enumerate(times):
+                parsed = self._parse_hhmm(time_text)
+                if parsed is None:
+                    logger.warning("已跳过无效的定时时间：%s", time_text)
+                    continue
+                hour, minute = parsed
+                cron_expression = f"{minute} {hour} * * *"
+                job = await cron_manager.add_basic_job(
+                    name=f"{plugin_id}_shitjournal_{idx}",
+                    cron_expression=cron_expression,
+                    handler=self._scheduled_tick,
+                    description=f"shitjournal 定时推送 {time_text}",
+                    timezone=timezone,
+                    payload={"schedule_time": time_text},
+                    enabled=True,
+                    persistent=False,
+                )
+                created_job_ids.append(job.job_id)
+                logger.info(
+                    "已注册定时任务：任务ID=%s 时间=%s 表达式=%s 时区=%s",
+                    job.job_id,
+                    time_text,
+                    cron_expression,
+                    timezone,
+                )
+        except Exception:
+            failed_ids = await self._delete_cron_jobs(cron_manager, created_job_ids)
+            self._cron_job_ids = failed_ids
+            await self.put_kv_data("cron_job_ids", failed_ids)
+            raise
 
         self._cron_job_ids = created_job_ids
         await self.put_kv_data("cron_job_ids", created_job_ids)
 
     async def _clear_cron_jobs(self) -> None:
+        ids = await self._load_cron_job_ids()
         cron_manager = getattr(self.context, "cron_manager", None)
         if cron_manager is None:
-            self._cron_job_ids = []
-            await self.put_kv_data("cron_job_ids", [])
+            self._cron_job_ids = ids
+            await self.put_kv_data("cron_job_ids", ids)
             return
 
-        ids = self._cron_job_ids
-        if not ids:
-            loaded = await self.get_kv_data("cron_job_ids", [])
-            if isinstance(loaded, list):
-                ids = [str(i) for i in loaded if str(i).strip()]
+        failed_ids = await self._delete_cron_jobs(cron_manager, ids)
+        self._cron_job_ids = failed_ids
+        await self.put_kv_data("cron_job_ids", failed_ids)
 
+    async def _load_cron_job_ids(self) -> list[str]:
+        ids = [str(job_id).strip() for job_id in self._cron_job_ids if str(job_id).strip()]
+        if ids:
+            return ids
+        loaded = await self.get_kv_data("cron_job_ids", [])
+        if not isinstance(loaded, list):
+            return []
+        return [str(job_id).strip() for job_id in loaded if str(job_id).strip()]
+
+    async def _delete_cron_jobs(self, cron_manager: Any, ids: list[str]) -> list[str]:
+        failed_ids: list[str] = []
         for job_id in ids:
             try:
                 await cron_manager.delete_job(job_id)
                 logger.info("已删除旧定时任务：%s", job_id)
             except Exception:
+                failed_ids.append(job_id)
                 logger.warning("删除定时任务失败，已忽略：%s", job_id, exc_info=True)
+        return failed_ids
 
-        self._cron_job_ids = []
-        await self.put_kv_data("cron_job_ids", [])
+    def _resolve_schedule_times(self) -> list[str]:
+        marker = object()
+        raw = self._cfg("schedule_times", marker)
+        if raw is marker:
+            return DEFAULT_SCHEDULE_TIMES.copy()
+        return self._normalize_schedule_times(raw)
 
     async def _scheduled_tick(self, schedule_time: str = "") -> None:
         report = await self._run_cycle(
@@ -1751,10 +1772,7 @@ class ShitJournalDailyPlugin(Star):
                 continue
             seen.add(formatted)
             normalized.append(formatted)
-
-        if normalized:
-            return normalized
-        return DEFAULT_SCHEDULE_TIMES.copy()
+        return normalized
 
     def _normalize_session_list(self, raw: Any) -> list[str]:
         if not isinstance(raw, list):

--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ import os
 import re
 import sys
 import time
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -16,9 +15,11 @@ from astrbot.api.star import Context, Star, StarTools, register
 
 if __package__:
     from .services import (
+        AssetPipeline,
         HistoryStore,
         PdfService,
         PushMessageService,
+        ReportRenderer,
         RunBatch,
         RunBatchReport,
         RunReason,
@@ -37,9 +38,11 @@ else:
     if str(_plugin_dir) not in sys.path:
         sys.path.insert(0, str(_plugin_dir))
     from services import (
+        AssetPipeline,
         HistoryStore,
         PdfService,
         PushMessageService,
+        ReportRenderer,
         RunBatch,
         RunBatchReport,
         RunReason,
@@ -147,7 +150,12 @@ class ShitJournalDailyPlugin(Star):
             normalize_session_list=self._normalize_session_list,
             normalize_zone_name=self._normalize_zone_name,
         )
-        self._run_selector = RunSelector(
+        self._run_selector = self._create_run_selector()
+        self._asset_pipeline = self._create_asset_pipeline()
+        self._report_renderer = self._create_report_renderer()
+
+    def _create_run_selector(self) -> RunSelector:
+        return RunSelector(
             fetch_latest_submissions=lambda zone, limit, offset: self._supabase.fetch_latest_submissions(
                 zone,
                 limit,
@@ -162,6 +170,34 @@ class ShitJournalDailyPlugin(Star):
                 session_key,
             ),
             logger=logger,
+        )
+
+    def _create_asset_pipeline(self) -> AssetPipeline:
+        return AssetPipeline(
+            fetch_submission_detail=self._supabase.fetch_submission_detail,
+            create_signed_pdf_url=self._supabase.create_signed_pdf_url,
+            download_pdf_file=self._supabase.download_pdf_file,
+            build_output_paths=self._temp_files.build_output_paths,
+            mark_in_use=self._temp_files.mark_in_use,
+            release_temp_files=self._temp_files.release,
+            ensure_pdf_size_limit=self._pdf_service.ensure_pdf_size_limit,
+            export_first_page_png=self._pdf_service.export_first_page_png,
+            logger=logger,
+            mask_sensitive_text=mask_sensitive_text,
+            detail_url_base=DETAIL_URL_BASE,
+            detail_hide_domain=lambda: self._cfg_bool("detail_hide_domain", False),
+            discipline_labels=DISCIPLINE_LABELS,
+            viscosity_labels=VISCOSITY_LABELS,
+            zone_labels=ZONE_LABELS,
+        )
+
+    def _create_report_renderer(self) -> ReportRenderer:
+        return ReportRenderer(
+            status_labels=REPORT_STATUS_LABELS,
+            reason_labels=REPORT_REASON_LABELS,
+            mask_sensitive_text=mask_sensitive_text,
+            detail_url_base=DETAIL_URL_BASE,
+            detail_hide_domain=lambda: self._cfg_bool("detail_hide_domain", False),
         )
 
     async def initialize(self):
@@ -259,7 +295,7 @@ class ShitJournalDailyPlugin(Star):
         if action == "run":
             force = bool(arg) and arg.split()[0] == "force"
             report = await self._run_cycle(force=force, source=f"手动:{event.get_sender_id()}")
-            yield event.plain_result(self._render_report(report))
+            yield event.plain_result(self._report_renderer.render_report(report))
             return
 
         help_text = (
@@ -651,7 +687,7 @@ class ShitJournalDailyPlugin(Star):
             source=f"定时:{schedule_time or '未知'}",
             latest_only=self._cfg_bool("schedule_latest_only", False),
         )
-        logger.info("定时推送执行完成：%s", self._render_report(report, include_debug=True))
+        logger.info("定时推送执行完成：%s", self._report_renderer.render_report(report, include_debug=True))
 
     async def _run_cycle(
         self,
@@ -939,7 +975,10 @@ class ShitJournalDailyPlugin(Star):
         zone: str,
     ) -> tuple[dict[str, Any], Path | None, Path | None, str, str]:
         payload = await self._load_submission_payload(latest, paper_id)
-        logger.info("论文元数据：%s", json.dumps(self._build_meta_preview(payload), ensure_ascii=False))
+        logger.info(
+            "论文元数据：%s",
+            json.dumps(self._asset_pipeline.build_meta_preview(payload), ensure_ascii=False),
+        )
         pdf_file, png_file, pdf_url = await self._prepare_pdf_assets(payload, paper_id)
         text = self._build_push_text(payload, detail_url, zone=zone)
         return payload, pdf_file, png_file, pdf_url, text
@@ -1074,11 +1113,6 @@ class ShitJournalDailyPlugin(Star):
             return value
         return RunBatchReport.from_dict(value)
 
-    def _to_run_report_dict(self, report: RunReport | dict[str, Any]) -> dict[str, Any]:
-        if isinstance(report, RunReport):
-            return report.to_dict()
-        return dict(report)
-
     def _resolve_batch_send_concurrency(self, batch_count: int) -> int:
         return min(MAX_BATCH_SEND_CONCURRENCY, self._get_configured_send_concurrency(), batch_count)
 
@@ -1089,12 +1123,6 @@ class ShitJournalDailyPlugin(Star):
         except (TypeError, ValueError):
             configured_concurrency = 3
         return min(MAX_SEND_CONCURRENCY, max(1, configured_concurrency))
-
-    def _render_status_text(self, status: str) -> str:
-        return REPORT_STATUS_LABELS.get(status, status)
-
-    def _render_reason_text(self, reason_code: str) -> str:
-        return REPORT_REASON_LABELS.get(reason_code, reason_code)
 
     def _pick_first_batch_debug_reason(self, batch_reports: list[RunBatchReport]) -> str:
         for batch_report in batch_reports:
@@ -1108,72 +1136,10 @@ class ShitJournalDailyPlugin(Star):
         latest: dict[str, Any],
         paper_id: str,
     ) -> dict[str, Any]:
-        payload = dict(latest)
-        if str(payload.get("pdf_path") or payload.get("file_path") or "").strip():
-            return payload
-
-        try:
-            detail = await self._supabase.fetch_submission_detail(paper_id)
-        except Exception:
-            logger.warning("获取论文详情失败，将回退为列表页载荷。", exc_info=True)
-            detail = {}
-        payload = {**payload, **(detail or {})}
-        return payload
+        return await self._asset_pipeline.load_submission_payload(latest, paper_id)
 
     async def _prepare_pdf_assets(self, payload: dict[str, Any], paper_id: str) -> tuple[Path, Path, str]:
-        pdf_key = str(payload.get("pdf_path") or payload.get("file_path") or "").strip()
-        if not pdf_key:
-            raise RuntimeError("PDF 路径缺失")
-
-        try:
-            signed_url = await self._supabase.create_signed_pdf_url(pdf_key)
-        except Exception as exc:
-            logger.error(
-                "生成签名 URL 失败：%s",
-                mask_sensitive_text(str(exc)),
-                exc_info=True,
-            )
-            raise RuntimeError("生成签名 URL 失败") from exc
-
-        if not signed_url:
-            raise RuntimeError("签名 URL 为空")
-
-        logger.info("已取得签名 PDF 地址：%s", self._mask_token(signed_url))
-        pdf_file, png_file = self._temp_files.build_output_paths(paper_id)
-        await self._temp_files.mark_in_use(pdf_file, png_file)
-
-        try:
-            try:
-                pdf_status, pdf_type = await self._supabase.download_pdf_file(
-                    signed_url,
-                    pdf_file,
-                )
-                logger.info("PDF 下载完成：状态码=%s 内容类型=%s", pdf_status, pdf_type)
-            except Exception as exc:
-                logger.error(
-                    "下载 PDF 失败：%s",
-                    mask_sensitive_text(str(exc)),
-                    exc_info=True,
-                )
-                raise RuntimeError("下载 PDF 失败") from exc
-
-            self._pdf_service.ensure_pdf_size_limit(pdf_file)
-            try:
-                await asyncio.to_thread(self._pdf_service.export_first_page_png, pdf_file, png_file)
-            except Exception as exc:
-                logger.error(
-                    "导出 PDF 首页预览图失败：%s",
-                    mask_sensitive_text(str(exc)),
-                    exc_info=True,
-                )
-                raise RuntimeError("导出 PDF 首页预览图失败") from exc
-
-            png_size = png_file.stat().st_size if png_file.exists() else 0
-            logger.info("PDF 首页预览图导出完成：文件=%s 字节数=%s", str(png_file), png_size)
-            return pdf_file, png_file, signed_url
-        except Exception:
-            await self._temp_files.release(pdf_file, png_file)
-            raise
+        return await self._asset_pipeline.prepare_pdf_assets(payload, paper_id)
 
     async def _send_push_to_targets(
         self,
@@ -1228,45 +1194,10 @@ class ShitJournalDailyPlugin(Star):
         detail_url: str,
         zone: str = "",
     ) -> str:
-        title = self._fallback_text(payload.get("manuscript_title"))
-        author = self._fallback_text(payload.get("author_name"))
-        institution = self._fallback_text(payload.get("institution"))
-        zone_text = self._format_bilingual_label(zone or payload.get("zone"), ZONE_LABELS)
-        submitted = self._format_datetime(payload.get("created_at"))
-        discipline = self._format_bilingual_label(payload.get("discipline"), DISCIPLINE_LABELS)
-        viscosity = self._format_bilingual_label(payload.get("viscosity"), VISCOSITY_LABELS)
-        avg_score = self._format_number(payload.get("avg_score"))
-        weighted_score = self._format_number(payload.get("weighted_score"))
-        rating_count = self._fallback_text(payload.get("rating_count"))
-        detail_text = self._format_detail_text(detail_url)
-        lines = [
-            "S.H.I.T Journal 论文推送",
-            f"分区: {zone_text}",
-            f"标题: {title}",
-            f"作者: {author}",
-            f"单位: {institution}",
-            f"提交时间: {submitted}",
-            f"学科: {discipline}",
-            f"粘度: {viscosity}",
-            f"评分: 平均={avg_score}, 加权={weighted_score}, 票数={rating_count}",
-            f"详情: {detail_text}",
-        ]
-        return "\n".join(lines)
+        return self._asset_pipeline.build_push_text(payload, detail_url, zone=zone)
 
     def _build_preprint_detail_url(self, paper_id: str) -> str:
-        normalized_paper_id = str(paper_id).strip()
-        return f"{DETAIL_URL_BASE}/preprints/{normalized_paper_id}"
-
-    def _format_detail_text(self, detail_url: str) -> str:
-        detail_text = str(detail_url or "").strip()
-        if not detail_text:
-            return detail_text
-        if not self._cfg_bool("detail_hide_domain", False):
-            return detail_text
-        if detail_text.startswith(DETAIL_URL_BASE):
-            path = detail_text[len(DETAIL_URL_BASE) :].strip()
-            return path if path.startswith("/") else f"/{path}"
-        return detail_text
+        return self._asset_pipeline.build_preprint_detail_url(paper_id)
 
     def _resolve_plugin_data_dir(self) -> Path:
         plugin_name = str(
@@ -1539,65 +1470,6 @@ class ShitJournalDailyPlugin(Star):
                 self._next_temp_trim_monotonic = 0.0
             raise
 
-    def _format_datetime(self, value: Any) -> str:
-        text = str(value or "").strip()
-        if not text:
-            return "无"
-        try:
-            dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
-            return dt.strftime("%Y-%m-%d %H:%M:%S")
-        except Exception:
-            return text
-
-    def _format_number(self, value: Any) -> str:
-        if value is None or value == "":
-            return "无"
-        try:
-            return f"{float(value):.4f}"
-        except Exception:
-            return str(value)
-
-    def _fallback_text(self, value: Any) -> str:
-        text = str(value or "").strip()
-        return text if text else "无"
-
-    def _format_bilingual_label(
-        self,
-        raw_value: Any,
-        mapping: dict[str, tuple[str, str]],
-    ) -> str:
-        text = str(raw_value or "").strip()
-        if not text:
-            return "无"
-        key = text.lower()
-        if key in mapping:
-            cn, en = mapping[key]
-            return f"{cn} / {en}"
-        return text
-
-    def _mask_token(self, url: str) -> str:
-        if "token=" not in url:
-            return url
-        head, _, _ = url.partition("token=")
-        return head + "token=<已隐藏>"
-
-    def _build_meta_preview(self, payload: dict[str, Any]) -> dict[str, Any]:
-        keys = [
-            "id",
-            "manuscript_title",
-            "author_name",
-            "institution",
-            "discipline",
-            "viscosity",
-            "created_at",
-            "avg_score",
-            "rating_count",
-            "weighted_score",
-            "pdf_path",
-            "zone",
-        ]
-        return {k: payload.get(k) for k in keys}
-
     def _build_zone_fetch_warning_text(
         self,
         *,
@@ -1657,167 +1529,3 @@ class ShitJournalDailyPlugin(Star):
             lines = ["抓取失败：已尝试所有可回退分区，但未能成功获取可推送论文。"]
         self._append_warning_lines(lines, warnings)
         return "\n".join(lines)
-
-    def _render_run_mode_text(self, latest_only: bool) -> str:
-        if latest_only:
-            return "模式: 仅检查最新一篇"
-        return ""
-
-    def _render_report_header(self, status_text: str, reason_text: str) -> list[str]:
-        return [
-            f"[shitjournal 执行结果] 状态: {status_text}",
-            f"原因: {reason_text}",
-        ]
-
-    def _render_report_batch_line(self, index: int, batch: dict[str, Any]) -> list[str]:
-        detail_text = self._format_detail_text(str(batch.get("detail_url", "")))
-        batch_status = str(batch.get("status", "unknown") or "unknown")
-        batch_status_text = self._render_status_text(batch_status)
-        batch_reason_code = str(batch.get("reason_code", "")).strip()
-        batch_reason_text = self._render_reason_text(batch_reason_code) if batch_reason_code else ""
-        suffix = f" 原因={batch_reason_text}" if batch_status == "failed" and batch_reason_text else ""
-        return [
-            (
-                f"第{index}批: 状态={batch_status_text} 分区={batch.get('zone', '')} "
-                f"论文ID={batch.get('paper_id', '')} "
-                f"推送={batch.get('sent_ok', 0)}/{batch.get('sent_total', 0)} "
-                f"详情={detail_text}{suffix}"
-            ),
-        ]
-
-    def _append_report_suffix(
-        self,
-        *,
-        lines: list[str],
-        latest_only: bool,
-        requested_zone: str,
-        report_zone: str,
-        warnings: list[str],
-        debug_reason: str,
-        include_debug: bool,
-    ) -> str:
-        mode_text = self._render_run_mode_text(latest_only)
-        if mode_text:
-            lines.append(mode_text)
-        if requested_zone and requested_zone != report_zone:
-            lines.append(f"请求分区: {requested_zone}")
-        self._append_warning_lines(lines, warnings)
-        if include_debug and debug_reason:
-            lines.append(f"调试信息: {debug_reason}")
-        return "\n".join(lines)
-
-    def _render_single_batch_report(
-        self,
-        report: dict[str, Any],
-        batch: dict[str, Any],
-        status_text: str,
-        reason_text: str,
-        latest_only: bool,
-        requested_zone: str,
-        warnings: list[str],
-        debug_reason: str,
-        include_debug: bool,
-    ) -> str:
-        lines = self._render_report_header(status_text, reason_text)
-        batch_reason_code = str(batch.get("reason_code", "")).strip()
-        lines.extend(
-            [
-                f"批次状态: {self._render_status_text(str(batch.get('status', 'unknown') or 'unknown'))}",
-                f"分区: {batch.get('zone', '')}",
-                f"论文 ID: {batch.get('paper_id', '')}",
-                f"推送: {batch.get('sent_ok', 0)}/{batch.get('sent_total', 0)}",
-                f"详情: {self._format_detail_text(str(batch.get('detail_url', '')))}",
-            ]
-        )
-        if batch_reason_code and batch_reason_code != "PUSHED_SUCCESSFULLY":
-            lines.append(f"批次原因: {self._render_reason_text(batch_reason_code)}")
-        return self._append_report_suffix(
-            lines=lines,
-            latest_only=latest_only,
-            requested_zone=requested_zone,
-            report_zone=str(report.get("zone", "")).strip(),
-            warnings=warnings,
-            debug_reason=debug_reason,
-            include_debug=include_debug,
-        )
-
-    def _render_multi_batch_report(
-        self,
-        report: dict[str, Any],
-        status_text: str,
-        reason_text: str,
-        latest_only: bool,
-        requested_zone: str,
-        warnings: list[str],
-        debug_reason: str,
-        include_debug: bool,
-    ) -> str:
-        batches = list(report.get("batches", []))
-        lines = self._render_report_header(status_text, reason_text)
-        lines.append(f"总批次: {len(batches)}")
-        lines.append(f"总推送: {report.get('sent_ok', 0)}/{report.get('sent_total', 0)}")
-        for index, batch in enumerate(batches, start=1):
-            lines.extend(self._render_report_batch_line(index, batch))
-        return self._append_report_suffix(
-            lines=lines,
-            latest_only=latest_only,
-            requested_zone=requested_zone,
-            report_zone=str(report.get("zone", "")).strip(),
-            warnings=warnings,
-            debug_reason=debug_reason,
-            include_debug=include_debug,
-        )
-
-    def _render_report(self, report: RunReport | dict[str, Any], include_debug: bool = False) -> str:
-        report_dict = self._to_run_report_dict(report)
-        status = str(report_dict.get("status", "unknown") or "unknown")
-        reason_code = str(report_dict.get("reason_code") or report_dict.get("reason") or "UNKNOWN")
-        debug_reason = mask_sensitive_text(str(report_dict.get("debug_reason", "")).strip())
-        latest_only = self._to_bool(report_dict.get("latest_only"), False)
-        requested_zone = str(report_dict.get("requested_zone", "")).strip()
-        warnings = self._clean_warning_list(report_dict.get("warnings", []))
-        status_text = self._render_status_text(status)
-        reason_text = self._render_reason_text(reason_code)
-        batches = list(report_dict.get("batches", []))
-        if len(batches) > 1:
-            return self._render_multi_batch_report(
-                report=report_dict,
-                status_text=status_text,
-                reason_text=reason_text,
-                latest_only=latest_only,
-                requested_zone=requested_zone,
-                warnings=warnings,
-                debug_reason=debug_reason,
-                include_debug=include_debug,
-            )
-        if len(batches) == 1:
-            return self._render_single_batch_report(
-                report=report_dict,
-                batch=batches[0],
-                status_text=status_text,
-                reason_text=reason_text,
-                latest_only=latest_only,
-                requested_zone=requested_zone,
-                warnings=warnings,
-                debug_reason=debug_reason,
-                include_debug=include_debug,
-            )
-        empty_batch = {
-            "status": str(report_dict.get("status", "unknown") or "unknown"),
-            "zone": str(report_dict.get("zone", "")).strip(),
-            "paper_id": str(report_dict.get("paper_id", "")).strip(),
-            "detail_url": str(report_dict.get("detail_url", "")).strip(),
-            "sent_ok": report_dict.get("sent_ok", 0),
-            "sent_total": report_dict.get("sent_total", 0),
-        }
-        return self._render_single_batch_report(
-            report=report_dict,
-            batch=empty_batch,
-            status_text=status_text,
-            reason_text=reason_text,
-            latest_only=latest_only,
-            requested_zone=requested_zone,
-            warnings=warnings,
-            debug_reason=debug_reason,
-            include_debug=include_debug,
-        )

--- a/main.py
+++ b/main.py
@@ -122,7 +122,6 @@ class ShitJournalDailyPlugin(Star):
         self._next_temp_trim_monotonic = 0.0
         self._plugin_data_dir = Path(".")
         self._temp_dir = Path(".")
-        self._send_concurrency = 3
         self._supabase = SupabaseClient(
             cfg_getter=self._cfg,
             cfg_int_getter=self._cfg_int,
@@ -245,7 +244,7 @@ class ShitJournalDailyPlugin(Star):
             ),
             get_primary_zone=self._get_primary_zone,
             get_candidate_zones=self._get_candidate_zones,
-            get_configured_send_concurrency=self._get_configured_send_concurrency,
+            get_configured_send_concurrency=self._run_batch_sender.get_configured_send_concurrency,
             maybe_trim_temp_files=lambda: self._maybe_trim_temp_files(),
             logger=logger,
             mask_sensitive_text=mask_sensitive_text,
@@ -253,6 +252,9 @@ class ShitJournalDailyPlugin(Star):
         )
 
     def _create_cron_scheduler(self) -> CronScheduler:
+        def _update_cron_job_ids(ids: list[str]) -> None:
+            self._cron_job_ids = [str(job_id).strip() for job_id in ids if str(job_id).strip()]
+
         return CronScheduler(
             context_getter=lambda: self.context,
             plugin_id_getter=lambda: getattr(self, "plugin_id", "shitjournal_daily"),
@@ -261,7 +263,7 @@ class ShitJournalDailyPlugin(Star):
             kv_getter=self.get_kv_data,
             kv_putter=self.put_kv_data,
             get_cron_job_ids=lambda: list(self._cron_job_ids),
-            set_cron_job_ids=self._set_cron_job_ids,
+            set_cron_job_ids=_update_cron_job_ids,
             run_cycle=lambda **kwargs: self._run_cycle_service.run_cycle(**kwargs),
             render_report=lambda report, include_debug=False: self._report_renderer.render_report(
                 report,
@@ -306,12 +308,6 @@ class ShitJournalDailyPlugin(Star):
         self._temp_dir = self._plugin_data_dir / "tmp"
         self._temp_files.set_temp_dir(self._temp_dir)
         self._ensure_supabase_key_or_raise()
-        self._send_concurrency = self._cfg_int(
-            "send_concurrency",
-            3,
-            min_value=1,
-            max_value=MAX_SEND_CONCURRENCY,
-        )
         self._temp_dir.mkdir(parents=True, exist_ok=True)
         await self._history_store.ensure_chi_shi_history_storage_ready()
         await self._cron_scheduler.clear_cron_jobs()
@@ -477,17 +473,6 @@ class ShitJournalDailyPlugin(Star):
         if is_private_message_session(session_key):
             return "当前私聊"
         return "当前会话"
-
-    def _set_cron_job_ids(self, ids: list[str]) -> None:
-        self._cron_job_ids = [str(job_id).strip() for job_id in ids if str(job_id).strip()]
-
-    def _get_configured_send_concurrency(self) -> int:
-        raw_concurrency = getattr(self, "_send_concurrency", 3)
-        try:
-            configured_concurrency = int(raw_concurrency)
-        except (TypeError, ValueError):
-            configured_concurrency = 3
-        return min(MAX_SEND_CONCURRENCY, max(1, configured_concurrency))
 
     def _resolve_plugin_data_dir(self) -> Path:
         plugin_name = str(

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_shitjournal_daily
 display_name: shitjournal_daily
 desc: 每日定时抓取并推送 shitjournal 最新论文
-version: v1.2.1
+version: v1.2.2
 astrbot_version: ">=4.9.2"
 author: qiyi71w
 repo: https://github.com/qiyi71w/astrbot_plugin_shitjournal_daily

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -9,6 +9,11 @@ __all__ = [
     "TempFileManager",
     "AssetPipeline",
     "ReportRenderer",
+    "CommandGate",
+    "CronScheduler",
+    "ChiShiService",
+    "RunBatchSender",
+    "RunCycleService",
     "RunSelector",
     "RunSelectionError",
     "ChiShiSelection",
@@ -38,6 +43,16 @@ def __getattr__(name: str):
         return import_module(".asset_pipeline", __name__).AssetPipeline
     if name == "ReportRenderer":
         return import_module(".report_renderer", __name__).ReportRenderer
+    if name == "CommandGate":
+        return import_module(".command_gate", __name__).CommandGate
+    if name == "CronScheduler":
+        return import_module(".cron_scheduler", __name__).CronScheduler
+    if name == "ChiShiService":
+        return import_module(".chi_shi_service", __name__).ChiShiService
+    if name == "RunBatchSender":
+        return import_module(".run_batch_sender", __name__).RunBatchSender
+    if name == "RunCycleService":
+        return import_module(".run_cycle_service", __name__).RunCycleService
     if name in {"RunSelector", "RunSelectionError", "ChiShiSelection", "RunSelectionResult"}:
         return getattr(import_module(".run_selector", __name__), name)
     if name in {"RunStatus", "RunReason", "RunBatch", "RunBatchReport", "RunReport", "PushRequest"}:

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -7,12 +7,17 @@ __all__ = [
     "PdfService",
     "PushMessageService",
     "TempFileManager",
+    "RunSelector",
+    "RunSelectionError",
+    "ChiShiSelection",
+    "RunSelectionResult",
     "RunStatus",
     "RunReason",
     "RunBatch",
     "RunBatchReport",
     "RunReport",
     "PushRequest",
+    "HistoryStore",
 ]
 
 
@@ -25,6 +30,10 @@ def __getattr__(name: str):
         return import_module(".push_message_service", __name__).PushMessageService
     if name == "TempFileManager":
         return import_module(".temp_file_manager", __name__).TempFileManager
+    if name == "HistoryStore":
+        return import_module(".history_store", __name__).HistoryStore
+    if name in {"RunSelector", "RunSelectionError", "ChiShiSelection", "RunSelectionResult"}:
+        return getattr(import_module(".run_selector", __name__), name)
     if name in {"RunStatus", "RunReason", "RunBatch", "RunBatchReport", "RunReport", "PushRequest"}:
         return getattr(import_module(".models", __name__), name)
     raise AttributeError(name)

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -2,7 +2,18 @@ from __future__ import annotations
 
 from importlib import import_module
 
-__all__ = ["SupabaseClient", "PdfService", "PushMessageService", "TempFileManager"]
+__all__ = [
+    "SupabaseClient",
+    "PdfService",
+    "PushMessageService",
+    "TempFileManager",
+    "RunStatus",
+    "RunReason",
+    "RunBatch",
+    "RunBatchReport",
+    "RunReport",
+    "PushRequest",
+]
 
 
 def __getattr__(name: str):
@@ -14,4 +25,6 @@ def __getattr__(name: str):
         return import_module(".push_message_service", __name__).PushMessageService
     if name == "TempFileManager":
         return import_module(".temp_file_manager", __name__).TempFileManager
+    if name in {"RunStatus", "RunReason", "RunBatch", "RunBatchReport", "RunReport", "PushRequest"}:
+        return getattr(import_module(".models", __name__), name)
     raise AttributeError(name)

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -7,6 +7,8 @@ __all__ = [
     "PdfService",
     "PushMessageService",
     "TempFileManager",
+    "AssetPipeline",
+    "ReportRenderer",
     "RunSelector",
     "RunSelectionError",
     "ChiShiSelection",
@@ -32,6 +34,10 @@ def __getattr__(name: str):
         return import_module(".temp_file_manager", __name__).TempFileManager
     if name == "HistoryStore":
         return import_module(".history_store", __name__).HistoryStore
+    if name == "AssetPipeline":
+        return import_module(".asset_pipeline", __name__).AssetPipeline
+    if name == "ReportRenderer":
+        return import_module(".report_renderer", __name__).ReportRenderer
     if name in {"RunSelector", "RunSelectionError", "ChiShiSelection", "RunSelectionResult"}:
         return getattr(import_module(".run_selector", __name__), name)
     if name in {"RunStatus", "RunReason", "RunBatch", "RunBatchReport", "RunReport", "PushRequest"}:

--- a/services/asset_pipeline.py
+++ b/services/asset_pipeline.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+DETAIL_URL_BASE = "https://shitjournal.org"
+SCORE_PRECISION = 4
+META_PREVIEW_KEYS = (
+    "id",
+    "manuscript_title",
+    "author_name",
+    "institution",
+    "discipline",
+    "viscosity",
+    "created_at",
+    "avg_score",
+    "rating_count",
+    "weighted_score",
+    "pdf_path",
+    "zone",
+)
+DEFAULT_DISCIPLINE_LABELS: dict[str, tuple[str, str]] = {
+    "interdisciplinary": ("交叉", "Interdisciplinary"),
+    "science": ("理", "Science"),
+    "engineering": ("工", "Engineering"),
+    "medical": ("医", "Medical"),
+    "agriculture": ("农", "Agriculture"),
+    "law_social": ("法社", "Law & Social"),
+    "humanities": ("文", "Humanities"),
+}
+DEFAULT_VISCOSITY_LABELS: dict[str, tuple[str, str]] = {
+    "stringy": ("拉丝型", "Stringy"),
+    "semi": ("半固态", "Semi-solid"),
+    "high-entropy": ("高熵态", "High-Entropy"),
+}
+DEFAULT_ZONE_LABELS: dict[str, tuple[str, str]] = {
+    "latrine": ("旱厕", "The Latrine"),
+    "septic": ("化粪池", "Septic Tank"),
+    "stone": ("构石", "The Stone"),
+    "sediment": ("沉淀区", "Sediment"),
+}
+
+
+class AssetPipeline:
+    def __init__(
+        self,
+        *,
+        fetch_submission_detail: Callable[[str], Awaitable[dict[str, Any]]],
+        create_signed_pdf_url: Callable[[str], Awaitable[str]],
+        download_pdf_file: Callable[[str, Path], Awaitable[tuple[int, str]]],
+        build_output_paths: Callable[[str], tuple[Path, Path]],
+        mark_in_use: Callable[[Path, Path], Awaitable[None]],
+        release_temp_files: Callable[[Path | None, Path | None], Awaitable[None]],
+        ensure_pdf_size_limit: Callable[[Path], None],
+        export_first_page_png: Callable[[Path, Path], None],
+        logger: Any,
+        mask_sensitive_text: Callable[[str], str],
+        detail_url_base: str = DETAIL_URL_BASE,
+        detail_hide_domain: Callable[[], bool] | None = None,
+        discipline_labels: dict[str, tuple[str, str]] | None = None,
+        viscosity_labels: dict[str, tuple[str, str]] | None = None,
+        zone_labels: dict[str, tuple[str, str]] | None = None,
+    ):
+        self._fetch_submission_detail = fetch_submission_detail
+        self._create_signed_pdf_url = create_signed_pdf_url
+        self._download_pdf_file = download_pdf_file
+        self._build_output_paths = build_output_paths
+        self._mark_in_use = mark_in_use
+        self._release_temp_files = release_temp_files
+        self._ensure_pdf_size_limit = ensure_pdf_size_limit
+        self._export_first_page_png = export_first_page_png
+        self._logger = logger
+        self._mask_sensitive_text = mask_sensitive_text
+        self._detail_url_base = str(detail_url_base).strip() or DETAIL_URL_BASE
+        self._detail_hide_domain = detail_hide_domain or (lambda: False)
+        self._discipline_labels = discipline_labels or DEFAULT_DISCIPLINE_LABELS
+        self._viscosity_labels = viscosity_labels or DEFAULT_VISCOSITY_LABELS
+        self._zone_labels = zone_labels or DEFAULT_ZONE_LABELS
+
+    async def load_submission_payload(
+        self,
+        latest: dict[str, Any],
+        paper_id: str,
+    ) -> dict[str, Any]:
+        payload = dict(latest)
+        if self._extract_pdf_key(payload):
+            return payload
+
+        try:
+            detail = await self._fetch_submission_detail(paper_id)
+        except Exception:
+            self._logger.warning("获取论文详情失败，将回退为列表页载荷。", exc_info=True)
+            detail = {}
+        return {**payload, **(detail or {})}
+
+    async def prepare_pdf_assets(self, payload: dict[str, Any], paper_id: str) -> tuple[Path, Path, str]:
+        pdf_key = self._extract_pdf_key(payload)
+        if not pdf_key:
+            raise RuntimeError("PDF 路径缺失")
+
+        signed_url = await self._load_signed_url(pdf_key)
+        if not signed_url:
+            raise RuntimeError("签名 URL 为空")
+
+        self._logger.info("已取得签名 PDF 地址：%s", self._mask_token(signed_url))
+        pdf_file, png_file = self._build_output_paths(paper_id)
+        await self._mark_in_use(pdf_file, png_file)
+
+        try:
+            await self._download_pdf(signed_url, pdf_file)
+            self._ensure_pdf_size_limit(pdf_file)
+            await self._export_first_page(pdf_file, png_file)
+            png_size = png_file.stat().st_size if png_file.exists() else 0
+            self._logger.info("PDF 首页预览图导出完成：文件=%s 字节数=%s", str(png_file), png_size)
+            return pdf_file, png_file, signed_url
+        except Exception:
+            await self._release_temp_files(pdf_file, png_file)
+            raise
+
+    def build_meta_preview(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return {key: payload.get(key) for key in META_PREVIEW_KEYS}
+
+    def build_preprint_detail_url(self, paper_id: str) -> str:
+        normalized_paper_id = str(paper_id).strip()
+        return f"{self._detail_url_base}/preprints/{normalized_paper_id}"
+
+    def build_push_text(
+        self,
+        payload: dict[str, Any],
+        detail_url: str,
+        *,
+        zone: str = "",
+    ) -> str:
+        title = self._fallback_text(payload.get("manuscript_title"))
+        author = self._fallback_text(payload.get("author_name"))
+        institution = self._fallback_text(payload.get("institution"))
+        zone_text = self._format_bilingual_label(zone or payload.get("zone"), self._zone_labels)
+        submitted = self._format_datetime(payload.get("created_at"))
+        discipline = self._format_bilingual_label(payload.get("discipline"), self._discipline_labels)
+        viscosity = self._format_bilingual_label(payload.get("viscosity"), self._viscosity_labels)
+        avg_score = self._format_number(payload.get("avg_score"))
+        weighted_score = self._format_number(payload.get("weighted_score"))
+        rating_count = self._fallback_text(payload.get("rating_count"))
+        detail_text = self._format_detail_text(detail_url)
+        lines = [
+            "S.H.I.T Journal 论文推送",
+            f"分区: {zone_text}",
+            f"标题: {title}",
+            f"作者: {author}",
+            f"单位: {institution}",
+            f"提交时间: {submitted}",
+            f"学科: {discipline}",
+            f"粘度: {viscosity}",
+            f"评分: 平均={avg_score}, 加权={weighted_score}, 票数={rating_count}",
+            f"详情: {detail_text}",
+        ]
+        return "\n".join(lines)
+
+    def _format_detail_text(self, detail_url: str) -> str:
+        detail_text = str(detail_url or "").strip()
+        if not detail_text:
+            return detail_text
+        if not self._detail_hide_domain():
+            return detail_text
+        if detail_text.startswith(self._detail_url_base):
+            path = detail_text[len(self._detail_url_base) :].strip()
+            return path if path.startswith("/") else f"/{path}"
+        return detail_text
+
+    async def _load_signed_url(self, pdf_key: str) -> str:
+        try:
+            return await self._create_signed_pdf_url(pdf_key)
+        except Exception as exc:
+            self._logger.error(
+                "生成签名 URL 失败：%s",
+                self._mask_sensitive_text(str(exc)),
+                exc_info=True,
+            )
+            raise RuntimeError("生成签名 URL 失败") from exc
+
+    async def _download_pdf(self, signed_url: str, pdf_file: Path) -> None:
+        try:
+            pdf_status, pdf_type = await self._download_pdf_file(signed_url, pdf_file)
+            self._logger.info("PDF 下载完成：状态码=%s 内容类型=%s", pdf_status, pdf_type)
+        except Exception as exc:
+            self._logger.error(
+                "下载 PDF 失败：%s",
+                self._mask_sensitive_text(str(exc)),
+                exc_info=True,
+            )
+            raise RuntimeError("下载 PDF 失败") from exc
+
+    async def _export_first_page(self, pdf_file: Path, png_file: Path) -> None:
+        try:
+            await asyncio.to_thread(self._export_first_page_png, pdf_file, png_file)
+        except Exception as exc:
+            self._logger.error(
+                "导出 PDF 首页预览图失败：%s",
+                self._mask_sensitive_text(str(exc)),
+                exc_info=True,
+            )
+            raise RuntimeError("导出 PDF 首页预览图失败") from exc
+
+    def _extract_pdf_key(self, payload: dict[str, Any]) -> str:
+        return str(payload.get("pdf_path") or payload.get("file_path") or "").strip()
+
+    def _format_datetime(self, value: Any) -> str:
+        text = str(value or "").strip()
+        if not text:
+            return "无"
+        try:
+            dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            return dt.strftime("%Y-%m-%d %H:%M:%S")
+        except Exception:
+            return text
+
+    def _format_number(self, value: Any) -> str:
+        if value is None or value == "":
+            return "无"
+        try:
+            return f"{float(value):.{SCORE_PRECISION}f}"
+        except Exception:
+            return str(value)
+
+    def _fallback_text(self, value: Any) -> str:
+        text = str(value or "").strip()
+        return text if text else "无"
+
+    def _format_bilingual_label(
+        self,
+        raw_value: Any,
+        mapping: dict[str, tuple[str, str]],
+    ) -> str:
+        text = str(raw_value or "").strip()
+        if not text:
+            return "无"
+        key = text.lower()
+        if key in mapping:
+            cn, en = mapping[key]
+            return f"{cn} / {en}"
+        return text
+
+    def _mask_token(self, url: str) -> str:
+        if "token=" not in url:
+            return url
+        head, _, _ = url.partition("token=")
+        return head + "token=<已隐藏>"

--- a/services/chi_shi_service.py
+++ b/services/chi_shi_service.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from .warning_text import append_warning_lines
+
+
+class ChiShiService:
+    def __init__(
+        self,
+        *,
+        select_candidate_from_zones: Callable[..., Awaitable[tuple[Any, bool, list[str]]]],
+        load_submission_payload: Callable[[dict[str, Any], str], Awaitable[dict[str, Any]]],
+        prepare_pdf_assets: Callable[[dict[str, Any], str], Awaitable[tuple[Path, Path, str]]],
+        build_push_text: Callable[[dict[str, Any], str, str], str],
+        build_preprint_detail_url: Callable[[str], str],
+        send_event_push: Callable[..., Awaitable[None]],
+        mark_chi_shi_paper_sent: Callable[[str, str, str], Awaitable[None]],
+        get_primary_zone: Callable[[], str],
+        get_candidate_zones: Callable[[str], list[str]],
+        build_zone_scope_text: Callable[[list[str]], str],
+        cfg_int_getter: Callable[[str, int, int | None, int | None], int],
+        mask_sensitive_text: Callable[[str], str],
+        fetch_page_size: int,
+    ):
+        self._select_candidate_from_zones = select_candidate_from_zones
+        self._load_submission_payload = load_submission_payload
+        self._prepare_pdf_assets = prepare_pdf_assets
+        self._build_push_text = build_push_text
+        self._build_preprint_detail_url = build_preprint_detail_url
+        self._send_event_push = send_event_push
+        self._mark_chi_shi_paper_sent = mark_chi_shi_paper_sent
+        self._get_primary_zone = get_primary_zone
+        self._get_candidate_zones = get_candidate_zones
+        self._build_zone_scope_text = build_zone_scope_text
+        self._cfg_int_getter = cfg_int_getter
+        self._mask_sensitive_text = mask_sensitive_text
+        self._fetch_page_size = int(fetch_page_size)
+        self._cooldown_lock = asyncio.Lock()
+        self._group_cooldown_until_monotonic: dict[str, float] = {}
+        self._group_inflight: set[str] = set()
+
+    async def execute_wo_yao_chi_shi(
+        self,
+        *,
+        event: Any,
+        session_key: str,
+        scope_label: str,
+    ) -> tuple[list[str], bool, Path | None, Path | None]:
+        primary_zone = self._get_primary_zone()
+        zone_order = self._get_candidate_zones(primary_zone)
+        selected, saw_candidates, warnings = await self._select_candidate_from_zones(
+            zone_order=zone_order,
+            session_key=session_key,
+            fetch_page_size=self._fetch_page_size,
+        )
+        if not selected:
+            apply_ok, reply = self.build_missing_chi_shi_selection_response(
+                zone_order=zone_order,
+                scope_label=scope_label,
+                saw_candidates=saw_candidates,
+                selection_warnings=warnings,
+            )
+            return [reply], apply_ok, None, None
+
+        apply_ok, pdf_file, png_file = await self.push_chi_shi_selection(
+            event=event,
+            session_key=session_key,
+            selection=selected,
+        )
+        if not apply_ok:
+            return ["候选论文缺少 ID。"], False, None, None
+        if not warnings:
+            return [], True, pdf_file, png_file
+        return [
+            self.build_chi_shi_success_text(
+                requested_zone=primary_zone,
+                selected_zone=str(selected.zone),
+                warnings=warnings,
+            ),
+        ], True, pdf_file, png_file
+
+    def build_missing_chi_shi_selection_response(
+        self,
+        *,
+        zone_order: list[str],
+        scope_label: str,
+        saw_candidates: bool,
+        selection_warnings: list[str],
+    ) -> tuple[bool, str]:
+        if selection_warnings:
+            return False, self.build_chi_shi_failure_text(
+                saw_candidates=saw_candidates,
+                warnings=selection_warnings,
+                scope_label=scope_label,
+            )
+        if saw_candidates:
+            zone_scope = self._build_zone_scope_text(zone_order)
+            return True, f"{scope_label}{zone_scope}最近这些论文都推送过了，等下一篇。"
+        return False, "未找到最新论文。"
+
+    async def push_chi_shi_selection(
+        self,
+        *,
+        event: Any,
+        session_key: str,
+        selection: Any,
+    ) -> tuple[bool, Path | None, Path | None]:
+        zone = str(selection.zone).strip()
+        paper_id = str(selection.paper_id).strip()
+        candidate = dict(selection.candidate or {})
+        if not paper_id:
+            return False, None, None
+
+        payload = await self._load_submission_payload(candidate, paper_id)
+        detail_url = self._build_preprint_detail_url(paper_id)
+        pdf_file, png_file, pdf_url = await self._prepare_pdf_assets(payload, paper_id)
+        text = self._build_push_text(payload, detail_url, zone)
+        await self._send_event_push(
+            event=event,
+            text=text,
+            png_file=png_file,
+            pdf_file=pdf_file,
+            pdf_url=pdf_url,
+        )
+        await self._mark_chi_shi_paper_sent(zone, session_key, paper_id)
+        return True, pdf_file, png_file
+
+    async def try_enter_chi_shi_cooldown(
+        self,
+        *,
+        session_key: str,
+        scope_label: str,
+        ignore_cooldown: bool,
+    ) -> tuple[bool, str]:
+        async with self._cooldown_lock:
+            if session_key in self._group_inflight:
+                return False, f"{scope_label}已有赤石任务在执行，请稍后再试。"
+            if ignore_cooldown:
+                self._group_inflight.add(session_key)
+                return True, ""
+
+            now = time.monotonic()
+            cooldown_until = float(self._group_cooldown_until_monotonic.get(session_key, 0.0))
+            remaining = cooldown_until - now
+            if remaining > 0:
+                return False, f"{scope_label}冷却中，请 {int(remaining + 0.999)} 秒后再试。"
+
+            self._group_inflight.add(session_key)
+            return True, ""
+
+    async def leave_chi_shi_cooldown(
+        self,
+        *,
+        session_key: str,
+        apply_success_cooldown: bool,
+        ignore_cooldown: bool,
+    ) -> None:
+        async with self._cooldown_lock:
+            self._group_inflight.discard(session_key)
+            if ignore_cooldown:
+                return
+            cooldown_sec = self._cfg_int_getter("chi_shi_group_cooldown_sec", 60, min_value=0)
+            fail_cooldown_sec = self._cfg_int_getter("chi_shi_group_fail_cooldown_sec", 10, min_value=0)
+            effective = cooldown_sec if apply_success_cooldown else fail_cooldown_sec
+            if effective > 0:
+                self._group_cooldown_until_monotonic[session_key] = time.monotonic() + effective
+                return
+            self._group_cooldown_until_monotonic.pop(session_key, None)
+
+    def build_chi_shi_success_text(
+        self,
+        *,
+        requested_zone: str,
+        selected_zone: str,
+        warnings: list[str],
+    ) -> str:
+        lines = ["已继续回退并完成推送。"]
+        if requested_zone and requested_zone != selected_zone:
+            lines.append(f"最终分区: {selected_zone}")
+        append_warning_lines(lines, warnings, self._mask_sensitive_text)
+        return "\n".join(lines)
+
+    def build_chi_shi_failure_text(
+        self,
+        *,
+        saw_candidates: bool,
+        warnings: list[str],
+        scope_label: str,
+    ) -> str:
+        if saw_candidates:
+            lines = [f"抓取失败：回退过程中存在分区抓取失败，无法确认{scope_label}是否都已推送。"]
+        else:
+            lines = ["抓取失败：已尝试所有可回退分区，但未能成功获取可推送论文。"]
+        append_warning_lines(lines, warnings, self._mask_sensitive_text)
+        return "\n".join(lines)

--- a/services/chi_shi_service.py
+++ b/services/chi_shi_service.py
@@ -19,6 +19,7 @@ class ChiShiService:
         build_preprint_detail_url: Callable[[str], str],
         send_event_push: Callable[..., Awaitable[None]],
         mark_chi_shi_paper_sent: Callable[[str, str, str], Awaitable[None]],
+        release_temp_files: Callable[[Path | None, Path | None], Awaitable[None]],
         get_primary_zone: Callable[[], str],
         get_candidate_zones: Callable[[str], list[str]],
         build_zone_scope_text: Callable[[list[str]], str],
@@ -33,6 +34,7 @@ class ChiShiService:
         self._build_preprint_detail_url = build_preprint_detail_url
         self._send_event_push = send_event_push
         self._mark_chi_shi_paper_sent = mark_chi_shi_paper_sent
+        self._release_temp_files = release_temp_files
         self._get_primary_zone = get_primary_zone
         self._get_candidate_zones = get_candidate_zones
         self._build_zone_scope_text = build_zone_scope_text
@@ -115,19 +117,30 @@ class ChiShiService:
         if not paper_id:
             return False, None, None
 
-        payload = await self._load_submission_payload(candidate, paper_id)
-        detail_url = self._build_preprint_detail_url(paper_id)
-        pdf_file, png_file, pdf_url = await self._prepare_pdf_assets(payload, paper_id)
-        text = self._build_push_text(payload, detail_url, zone)
-        await self._send_event_push(
-            event=event,
-            text=text,
-            png_file=png_file,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
-        )
-        await self._mark_chi_shi_paper_sent(zone, session_key, paper_id)
-        return True, pdf_file, png_file
+        pdf_file: Path | None = None
+        png_file: Path | None = None
+        try:
+            payload = await self._load_submission_payload(candidate, paper_id)
+            detail_url = self._build_preprint_detail_url(paper_id)
+            pdf_file, png_file, pdf_url = await self._prepare_pdf_assets(payload, paper_id)
+            text = self._build_push_text(payload, detail_url, zone)
+            await self._send_event_push(
+                event=event,
+                text=text,
+                png_file=png_file,
+                pdf_file=pdf_file,
+                pdf_url=pdf_url,
+            )
+            await self._mark_chi_shi_paper_sent(zone, session_key, paper_id)
+            return True, pdf_file, png_file
+        except Exception as exc:
+            if pdf_file is None and png_file is None:
+                raise
+            try:
+                await self._release_temp_files(pdf_file, png_file)
+            except Exception as release_exc:
+                raise release_exc from exc
+            raise
 
     async def try_enter_chi_shi_cooldown(
         self,

--- a/services/command_gate.py
+++ b/services/command_gate.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Callable
+
+from astrbot.api.event import AstrMessageEvent
+
+
+class CommandGate:
+    def __init__(
+        self,
+        *,
+        context_getter: Callable[[], Any],
+        cfg_bool_getter: Callable[[str, bool], bool],
+        logger: Any,
+    ):
+        self._context_getter = context_getter
+        self._cfg_bool_getter = cfg_bool_getter
+        self._logger = logger
+
+    async def check_command_permission(self, event: AstrMessageEvent) -> bool:
+        if not self.looks_like_message_event(event):
+            self._logger.error("指令权限检查失败：无效事件类型=%s", type(event).__name__)
+            return False
+        if not self._cfg_bool_getter("command_admin_only", True):
+            return True
+        if self.is_admin_event(event):
+            return True
+        if self._cfg_bool_getter("command_no_permission_reply", True):
+            await event.send(event.plain_result("权限不足：仅管理员可使用该指令。"))
+        event.stop_event()
+        return False
+
+    def normalize_command_event(
+        self,
+        event: Any,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        command_name: str,
+    ) -> tuple[AstrMessageEvent, tuple[Any, ...], dict[str, Any]] | None:
+        if self.looks_like_message_event(event):
+            return event, args, kwargs
+
+        candidate = kwargs.get("event")
+        if self.looks_like_message_event(candidate):
+            cleaned_kwargs = dict(kwargs)
+            cleaned_kwargs.pop("event", None)
+            self._logger.warning(
+                "指令 %s 从 kwargs 中修正了偏移的事件对象（原类型=%s）。",
+                command_name,
+                type(event).__name__,
+            )
+            return candidate, args, cleaned_kwargs
+
+        for idx, item in enumerate(args):
+            if not self.looks_like_message_event(item):
+                continue
+            shifted_args = args[:idx] + args[idx + 1 :]
+            self._logger.warning(
+                "指令 %s 从 args[%d] 中修正了偏移的事件对象（原类型=%s）。",
+                command_name,
+                idx,
+                type(event).__name__,
+            )
+            return item, shifted_args, kwargs
+
+        self._logger.error(
+            "指令 %s 事件归一化失败：event_type=%s args_types=%s kwargs_keys=%s",
+            command_name,
+            type(event).__name__,
+            [type(item).__name__ for item in args[:4]],
+            list(kwargs.keys())[:8],
+        )
+        return None
+
+    def looks_like_message_event(self, value: Any) -> bool:
+        if isinstance(value, AstrMessageEvent):
+            return True
+        required = (
+            "plain_result",
+            "send",
+            "stop_event",
+            "unified_msg_origin",
+        )
+        if value is None or not all(hasattr(value, attr) for attr in required):
+            return False
+        return callable(getattr(value, "get_sender_id", None))
+
+    def is_admin_event(self, event: AstrMessageEvent) -> bool:
+        is_admin = getattr(event, "is_admin", None)
+        if callable(is_admin) and is_admin():
+            return True
+        return self.is_sender_in_admins(event)
+
+    def is_sender_in_admins(self, event: AstrMessageEvent) -> bool:
+        sender_id = str(event.get_sender_id()).strip()
+        if not sender_id:
+            return False
+
+        config_obj: Any = getattr(self._context_getter(), "astrbot_config", None)
+        if not isinstance(config_obj, dict):
+            return False
+
+        admins_raw = config_obj.get("admins_id", [])
+        if isinstance(admins_raw, str):
+            normalized_admins = [part.strip() for part in admins_raw.split(",")]
+        elif isinstance(admins_raw, (list, tuple, set)):
+            normalized_admins = [str(part).strip() for part in admins_raw]
+        else:
+            normalized_admins = []
+        admins = {item for item in normalized_admins if item}
+        return sender_id in admins
+
+    def parse_command_action_arg(
+        self,
+        *,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        default_action: str,
+    ) -> tuple[str, str]:
+        positional_action: Any = args[0] if len(args) >= 1 else None
+        positional_arg: Any = args[1] if len(args) >= 2 else None
+        positional_extra: Any = list(args[2:]) if len(args) >= 3 else None
+        default_action_normalized = default_action.strip().lower()
+
+        action_tokens = self._pick_command_tokens(
+            kwargs=kwargs,
+            primary_key="action",
+            alias_key="_action",
+            positional_value=positional_action,
+        )
+        arg_tokens = self._pick_command_tokens(
+            kwargs=kwargs,
+            primary_key="arg",
+            alias_key="_arg",
+            positional_value=positional_arg,
+        )
+        extra_tokens = self._pick_command_tokens(
+            kwargs=kwargs,
+            primary_key="extra_args",
+            alias_key="_extra_args",
+            positional_value=positional_extra,
+        )
+
+        action = action_tokens[0] if action_tokens else default_action_normalized
+        action = action or default_action_normalized
+        merged_arg_tokens = action_tokens[1:] + arg_tokens + extra_tokens
+        if action == default_action_normalized and merged_arg_tokens:
+            action = merged_arg_tokens.pop(0)
+        return action, " ".join(merged_arg_tokens).strip()
+
+    def parse_action_arg_from_message(
+        self,
+        *,
+        event: AstrMessageEvent,
+        command_name: str,
+    ) -> tuple[str, str]:
+        message_text = ""
+        getter = getattr(event, "get_message_str", None)
+        if callable(getter):
+            message_text = str(getter() or "")
+        if not message_text:
+            message_text = str(getattr(event, "message_str", "") or "")
+
+        text = re.sub(r"\s+", " ", message_text).strip().lower()
+        command = command_name.strip().lower()
+        if not text or not command:
+            return "", ""
+
+        for candidate in (command, f"/{command}"):
+            if text == candidate:
+                return "help", ""
+            if not text.startswith(f"{candidate} "):
+                continue
+            tail = text[len(candidate) :].strip()
+            if not tail:
+                return "help", ""
+            tokens = [part for part in tail.split(" ") if part]
+            action = tokens[0] if tokens else "help"
+            arg = " ".join(tokens[1:]).strip() if len(tokens) >= 2 else ""
+            return action, arg
+
+        return "", ""
+
+    def _pick_command_tokens(
+        self,
+        *,
+        kwargs: dict[str, Any],
+        primary_key: str,
+        alias_key: str,
+        positional_value: Any,
+    ) -> list[str]:
+        if primary_key in kwargs:
+            tokens = self._split_command_tokens(kwargs.get(primary_key))
+            if tokens:
+                return tokens
+        if alias_key in kwargs:
+            tokens = self._split_command_tokens(kwargs.get(alias_key))
+            if tokens:
+                return tokens
+        return self._split_command_tokens(positional_value)
+
+    def _split_command_tokens(self, value: Any) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, (list, tuple)):
+            tokens: list[str] = []
+            for item in value:
+                tokens.extend(self._split_command_tokens(item))
+            return tokens
+
+        text = str(value).strip().lower()
+        if not text:
+            return []
+        return [part for part in text.split() if part]

--- a/services/cron_scheduler.py
+++ b/services/cron_scheduler.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Awaitable, Callable
+
+
+class CronScheduler:
+    def __init__(
+        self,
+        *,
+        context_getter: Callable[[], Any],
+        plugin_id_getter: Callable[[], str],
+        cfg_getter: Callable[[str, Any], Any],
+        cfg_bool_getter: Callable[[str, bool], bool],
+        kv_getter: Callable[[str, Any], Awaitable[Any]],
+        kv_putter: Callable[[str, Any], Awaitable[None]],
+        get_cron_job_ids: Callable[[], list[str]],
+        set_cron_job_ids: Callable[[list[str]], None],
+        scheduled_handler: Callable[..., Awaitable[None]],
+        run_cycle: Callable[..., Awaitable[Any]],
+        render_report: Callable[..., str],
+        logger: Any,
+        default_schedule_times: list[str],
+    ):
+        self._context_getter = context_getter
+        self._plugin_id_getter = plugin_id_getter
+        self._cfg_getter = cfg_getter
+        self._cfg_bool_getter = cfg_bool_getter
+        self._kv_getter = kv_getter
+        self._kv_putter = kv_putter
+        self._get_cron_job_ids = get_cron_job_ids
+        self._set_cron_job_ids = set_cron_job_ids
+        self._scheduled_handler = scheduled_handler
+        self._run_cycle = run_cycle
+        self._render_report = render_report
+        self._logger = logger
+        self._default_schedule_times = list(default_schedule_times)
+
+    async def register_cron_jobs(self) -> None:
+        cron_manager = getattr(self._context_getter(), "cron_manager", None)
+        if cron_manager is None:
+            self._logger.error("cron_manager 不可用，已跳过定时任务注册。")
+            return
+
+        timezone = str(self._cfg_getter("timezone", "Asia/Shanghai")).strip() or "Asia/Shanghai"
+        times = self.resolve_schedule_times()
+        plugin_id = self._plugin_id_getter()
+        created_job_ids: list[str] = []
+        try:
+            for idx, time_text in enumerate(times):
+                parsed = self.parse_hhmm(time_text)
+                if parsed is None:
+                    self._logger.warning("已跳过无效的定时时间：%s", time_text)
+                    continue
+                await self._register_single_job(
+                    cron_manager=cron_manager,
+                    plugin_id=plugin_id,
+                    timezone=timezone,
+                    index=idx,
+                    time_text=time_text,
+                    parsed=parsed,
+                    created_job_ids=created_job_ids,
+                )
+        except Exception:
+            failed_ids = await self.delete_cron_jobs(cron_manager, created_job_ids)
+            self._set_cron_job_ids(failed_ids)
+            await self._kv_putter("cron_job_ids", failed_ids)
+            raise
+
+        self._set_cron_job_ids(created_job_ids)
+        await self._kv_putter("cron_job_ids", created_job_ids)
+
+    async def _register_single_job(
+        self,
+        *,
+        cron_manager: Any,
+        plugin_id: str,
+        timezone: str,
+        index: int,
+        time_text: str,
+        parsed: tuple[int, int],
+        created_job_ids: list[str],
+    ) -> None:
+        hour, minute = parsed
+        cron_expression = f"{minute} {hour} * * *"
+        job = await cron_manager.add_basic_job(
+            name=f"{plugin_id}_shitjournal_{index}",
+            cron_expression=cron_expression,
+            handler=self._scheduled_handler,
+            description=f"shitjournal 定时推送 {time_text}",
+            timezone=timezone,
+            payload={"schedule_time": time_text},
+            enabled=True,
+            persistent=False,
+        )
+        created_job_ids.append(job.job_id)
+        self._logger.info(
+            "已注册定时任务：任务ID=%s 时间=%s 表达式=%s 时区=%s",
+            job.job_id,
+            time_text,
+            cron_expression,
+            timezone,
+        )
+
+    async def clear_cron_jobs(self) -> None:
+        ids = await self.load_cron_job_ids()
+        cron_manager = getattr(self._context_getter(), "cron_manager", None)
+        if cron_manager is None:
+            self._set_cron_job_ids(ids)
+            await self._kv_putter("cron_job_ids", ids)
+            return
+
+        failed_ids = await self.delete_cron_jobs(cron_manager, ids)
+        self._set_cron_job_ids(failed_ids)
+        await self._kv_putter("cron_job_ids", failed_ids)
+
+    async def load_cron_job_ids(self) -> list[str]:
+        ids = [str(job_id).strip() for job_id in self._get_cron_job_ids() if str(job_id).strip()]
+        if ids:
+            return ids
+        loaded = await self._kv_getter("cron_job_ids", [])
+        if not isinstance(loaded, list):
+            return []
+        return [str(job_id).strip() for job_id in loaded if str(job_id).strip()]
+
+    async def delete_cron_jobs(self, cron_manager: Any, ids: list[str]) -> list[str]:
+        failed_ids: list[str] = []
+        for job_id in ids:
+            try:
+                await cron_manager.delete_job(job_id)
+                self._logger.info("已删除旧定时任务：%s", job_id)
+            except Exception:
+                failed_ids.append(job_id)
+                self._logger.warning("删除定时任务失败，已忽略：%s", job_id, exc_info=True)
+        return failed_ids
+
+    def resolve_schedule_times(self) -> list[str]:
+        marker = object()
+        raw = self._cfg_getter("schedule_times", marker)
+        if raw is marker:
+            return self._default_schedule_times.copy()
+        return self.normalize_schedule_times(raw)
+
+    async def scheduled_tick(self, schedule_time: str = "") -> None:
+        report = await self._run_cycle(
+            force=False,
+            source=f"定时:{schedule_time or '未知'}",
+            latest_only=self._cfg_bool_getter("schedule_latest_only", False),
+        )
+        self._logger.info(
+            "定时推送执行完成：%s",
+            self._render_report(report, include_debug=True),
+        )
+
+    def parse_hhmm(self, value: str) -> tuple[int, int] | None:
+        text = str(value).strip()
+        match = re.match(r"^([01]?\d|2[0-3]):([0-5]\d)$", text)
+        if not match:
+            return None
+        return int(match.group(1)), int(match.group(2))
+
+    def normalize_schedule_times(self, raw: Any) -> list[str]:
+        values: list[str]
+        if isinstance(raw, str):
+            values = [item.strip() for item in re.split(r"[,\s]+", raw) if item.strip()]
+        elif isinstance(raw, list):
+            values = [str(item).strip() for item in raw if str(item).strip()]
+        else:
+            values = []
+
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for value in values:
+            parsed = self.parse_hhmm(value)
+            if parsed is None:
+                continue
+            formatted = f"{parsed[0]:02d}:{parsed[1]:02d}"
+            if formatted in seen:
+                continue
+            seen.add(formatted)
+            normalized.append(formatted)
+        return normalized

--- a/services/cron_scheduler.py
+++ b/services/cron_scheduler.py
@@ -16,7 +16,6 @@ class CronScheduler:
         kv_putter: Callable[[str, Any], Awaitable[None]],
         get_cron_job_ids: Callable[[], list[str]],
         set_cron_job_ids: Callable[[list[str]], None],
-        scheduled_handler: Callable[..., Awaitable[None]],
         run_cycle: Callable[..., Awaitable[Any]],
         render_report: Callable[..., str],
         logger: Any,
@@ -30,7 +29,6 @@ class CronScheduler:
         self._kv_putter = kv_putter
         self._get_cron_job_ids = get_cron_job_ids
         self._set_cron_job_ids = set_cron_job_ids
-        self._scheduled_handler = scheduled_handler
         self._run_cycle = run_cycle
         self._render_report = render_report
         self._logger = logger
@@ -86,7 +84,7 @@ class CronScheduler:
         job = await cron_manager.add_basic_job(
             name=f"{plugin_id}_shitjournal_{index}",
             cron_expression=cron_expression,
-            handler=self._scheduled_handler,
+            handler=self.scheduled_tick,
             description=f"shitjournal 定时推送 {time_text}",
             timezone=timezone,
             payload={"schedule_time": time_text},

--- a/services/history_store.py
+++ b/services/history_store.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+import asyncio
+from typing import Any, Awaitable, Callable
+RUN_SENT_HISTORY_STORAGE_VERSION = "2"
+RUN_SENT_HISTORY_STORAGE_VERSION_KEY = "run_sent_history_storage_version"
+RUN_SENT_HISTORY_KV_PREFIX = "run_sent_history_v2::"
+CHI_SHI_HISTORY_STORAGE_VERSION = "2"
+CHI_SHI_HISTORY_STORAGE_VERSION_KEY = "chi_shi_sent_history_storage_version"
+CHI_SHI_HISTORY_KV_PREFIX = "chi_shi_sent_history_v2::"
+class HistoryStore:
+    def __init__(
+        self,
+        *,
+        kv_getter: Callable[[str, Any], Awaitable[Any]],
+        kv_putter: Callable[[str, Any], Awaitable[None]],
+        cfg_bool_getter: Callable[[str, bool], bool],
+        cfg_int_getter: Callable[[str, int, int | None, int | None], int],
+        normalize_session_list: Callable[[Any], list[str]],
+        normalize_zone_name: Callable[[Any], str],
+    ):
+        self._kv_getter = kv_getter
+        self._kv_putter = kv_putter
+        self._cfg_bool_getter = cfg_bool_getter
+        self._cfg_int_getter = cfg_int_getter
+        self._normalize_session_list = normalize_session_list
+        self._normalize_zone_name = normalize_zone_name
+        self._bound_sessions_lock = asyncio.Lock()
+        self._run_sent_history_lock = asyncio.Lock()
+        self._run_sent_history_storage_ready = False
+        self._chi_shi_dedupe_lock = asyncio.Lock()
+        self._chi_shi_history_storage_ready = False
+    async def get_bound_sessions(self) -> list[str]:
+        raw = await self._kv_getter("bound_sessions", [])
+        return self._normalize_sessions(raw)
+    async def set_bound_sessions(self, sessions: list[str]) -> None:
+        normalized = self._normalize_sessions(sessions)
+        await self._kv_putter("bound_sessions", normalized)
+    async def bind_session(self, session: str) -> bool:
+        normalized_session = self._normalize_session(session)
+        if not normalized_session:
+            return False
+        async with self._bound_sessions_lock:
+            bound = await self.get_bound_sessions()
+            if normalized_session in bound:
+                return False
+            bound.append(normalized_session)
+            await self.set_bound_sessions(bound)
+            return True
+    async def unbind_session(self, session: str) -> bool:
+        normalized_session = self._normalize_session(session)
+        if not normalized_session:
+            return False
+        async with self._bound_sessions_lock:
+            bound = await self.get_bound_sessions()
+            if normalized_session not in bound:
+                return False
+            updated = [item for item in bound if item != normalized_session]
+            await self.set_bound_sessions(updated)
+            return True
+    async def get_all_target_sessions(self, cfg_targets_raw: Any) -> list[str]:
+        cfg_targets = self._normalize_sessions(cfg_targets_raw)
+        bound = await self.get_bound_sessions()
+        merged: list[str] = []
+        seen: set[str] = set()
+        for item in cfg_targets + bound:
+            if item in seen:
+                continue
+            seen.add(item)
+            merged.append(item)
+        return merged
+    async def get_last_seen_map(self) -> dict[str, str]:
+        raw = await self._kv_getter("last_seen_by_zone", {})
+        return self._clean_kv_dict(raw)
+    async def set_last_seen_map(self, last_seen_map: dict[str, str]) -> None:
+        await self._kv_putter("last_seen_by_zone", self._clean_kv_dict(last_seen_map))
+    async def ensure_run_sent_history_storage_ready(self) -> None:
+        if self._run_sent_history_storage_ready:
+            return
+        async with self._run_sent_history_lock:
+            if self._run_sent_history_storage_ready:
+                return
+            version = str(await self._kv_getter(RUN_SENT_HISTORY_STORAGE_VERSION_KEY, "") or "").strip()
+            if version == RUN_SENT_HISTORY_STORAGE_VERSION:
+                self._run_sent_history_storage_ready = True
+                return
+            legacy_raw = await self._kv_getter("last_sent_by_target_zone", {})
+            merged = self._build_legacy_run_sent_histories(legacy_raw)
+            for target_zone_key, history in merged.items():
+                zone, _, session = target_zone_key.partition("::")
+                if not session:
+                    continue
+                await self._kv_putter(self._run_history_store_key(zone, session), history)
+            if legacy_raw:
+                await self._kv_putter("last_sent_by_target_zone", {})
+            await self._kv_putter(RUN_SENT_HISTORY_STORAGE_VERSION_KEY, RUN_SENT_HISTORY_STORAGE_VERSION)
+            self._run_sent_history_storage_ready = True
+    async def get_run_sent_history(self, zone: str, session: str) -> list[str]:
+        normalized_session = self._normalize_session(session)
+        if not normalized_session:
+            return []
+        await self.ensure_run_sent_history_storage_ready()
+        return await self._get_run_sent_history_unlocked(zone, normalized_session)
+    async def get_run_sent_histories(self, zone: str, targets: list[str]) -> dict[str, list[str]]:
+        normalized_targets = self._normalize_sessions(targets)
+        if not normalized_targets:
+            return {}
+        await self.ensure_run_sent_history_storage_ready()
+        raw_histories = await asyncio.gather(
+            *[self._kv_getter(self._run_history_store_key(zone, session), []) for session in normalized_targets],
+        )
+        return {
+            session: self._clean_kv_list(raw_history)
+            for session, raw_history in zip(normalized_targets, raw_histories)
+        }
+    async def mark_run_targets_delivered(
+        self,
+        *,
+        zone: str,
+        paper_id: str,
+        success_targets: list[str],
+    ) -> None:
+        normalized_targets = self._normalize_sessions(success_targets)
+        if not normalized_targets:
+            return
+        await self.ensure_run_sent_history_storage_ready()
+        async with self._run_sent_history_lock:
+            for session in normalized_targets:
+                current_history = await self._get_run_sent_history_unlocked(zone, session)
+                updated_history = self._prepend_history_item(current_history, paper_id)
+                await self._kv_putter(self._run_history_store_key(zone, session), updated_history)
+    async def ensure_chi_shi_history_storage_ready(self) -> None:
+        if self._chi_shi_history_storage_ready:
+            return
+        async with self._chi_shi_dedupe_lock:
+            if self._chi_shi_history_storage_ready:
+                return
+            version = str(await self._kv_getter(CHI_SHI_HISTORY_STORAGE_VERSION_KEY, "") or "").strip()
+            if version == CHI_SHI_HISTORY_STORAGE_VERSION:
+                self._chi_shi_history_storage_ready = True
+                return
+            merged = await self._load_legacy_chi_shi_histories()
+            for group_zone_key, history in merged.items():
+                zone, _, session = group_zone_key.partition("::")
+                if not session:
+                    continue
+                await self._kv_putter(self._chi_shi_history_store_key(zone, session), history)
+            await self._kv_putter(CHI_SHI_HISTORY_STORAGE_VERSION_KEY, CHI_SHI_HISTORY_STORAGE_VERSION)
+            self._chi_shi_history_storage_ready = True
+    async def get_chi_shi_sent_history(self, zone: str, session: str) -> list[str]:
+        normalized_session = self._normalize_session(session)
+        if not normalized_session:
+            return []
+        await self.ensure_chi_shi_history_storage_ready()
+        async with self._chi_shi_dedupe_lock:
+            return await self._get_chi_shi_sent_history_unlocked(zone, normalized_session)
+    async def mark_chi_shi_paper_sent(
+        self,
+        zone: str,
+        session: str,
+        paper_id: str,
+    ) -> None:
+        normalized_session = self._normalize_session(session)
+        if not normalized_session:
+            return
+        await self.ensure_chi_shi_history_storage_ready()
+        async with self._chi_shi_dedupe_lock:
+            history = await self._get_chi_shi_sent_history_unlocked(zone, normalized_session)
+            await self._kv_putter(
+                self._chi_shi_history_store_key(zone, normalized_session),
+                self._apply_chi_shi_history_policy(self._prepend_history_item(history, paper_id)),
+            )
+    def _run_history_store_key(self, zone: str, session: str) -> str:
+        return f"{RUN_SENT_HISTORY_KV_PREFIX}{self._target_zone_key(zone, session)}"
+    def _target_zone_key(self, zone: str, session: str) -> str:
+        return f"{self._normalize_zone_name(zone)}::{session}"
+    def _normalize_target_zone_key(self, raw_key: Any) -> str:
+        text = str(raw_key or "").strip()
+        if not text:
+            return ""
+        zone, sep, session = text.partition("::")
+        if not sep:
+            return ""
+        session = session.strip()
+        if not session:
+            return ""
+        return self._target_zone_key(zone, session)
+    def _build_legacy_run_sent_histories(self, legacy_raw: Any) -> dict[str, list[str]]:
+        merged: dict[str, list[str]] = {}
+        for raw_key, paper_id in self._clean_kv_dict(legacy_raw).items():
+            key = self._normalize_target_zone_key(raw_key)
+            if not key:
+                continue
+            merged[key] = [paper_id]
+        return merged
+    async def _get_run_sent_history_unlocked(self, zone: str, session: str) -> list[str]:
+        raw = await self._kv_getter(self._run_history_store_key(zone, session), [])
+        return self._clean_kv_list(raw)
+    def _chi_shi_group_zone_key(self, zone: str, session: str) -> str:
+        return f"{self._normalize_zone_name(zone)}::{session}"
+    def _chi_shi_history_store_key(self, zone: str, session: str) -> str:
+        return f"{CHI_SHI_HISTORY_KV_PREFIX}{self._chi_shi_group_zone_key(zone, session)}"
+    def _normalize_group_zone_key(self, raw_key: Any) -> str:
+        text = str(raw_key or "").strip()
+        if not text:
+            return ""
+        zone, sep, session = text.partition("::")
+        if not sep:
+            return ""
+        session = session.strip()
+        if not session:
+            return ""
+        return self._chi_shi_group_zone_key(zone, session)
+    async def _load_legacy_chi_shi_histories(self) -> dict[str, list[str]]:
+        history_raw = await self._kv_getter("chi_shi_sent_history_by_group_zone", {})
+        legacy_raw = await self._kv_getter("chi_shi_last_sent_by_group_zone", {})
+        merged: dict[str, list[str]] = {}
+        for raw_key, history in self._clean_kv_list_dict(history_raw).items():
+            key = self._normalize_group_zone_key(raw_key)
+            if not key:
+                continue
+            merged[key] = self._apply_chi_shi_history_policy(history)
+        for raw_key, paper_id in self._clean_kv_dict(legacy_raw).items():
+            key = self._normalize_group_zone_key(raw_key)
+            if not key:
+                continue
+            history = merged.get(key, [])
+            if paper_id not in history:
+                history = history + [paper_id]
+            merged[key] = self._apply_chi_shi_history_policy(history)
+        return {key: history for key, history in merged.items() if history}
+    async def _get_chi_shi_sent_history_unlocked(self, zone: str, session: str) -> list[str]:
+        raw = await self._kv_getter(self._chi_shi_history_store_key(zone, session), [])
+        return self._apply_chi_shi_history_policy(self._clean_kv_list(raw))
+    def _apply_chi_shi_history_policy(self, history: list[str]) -> list[str]:
+        if self._cfg_bool_getter("chi_shi_keep_full_history", True):
+            return history
+        limit = self._cfg_int_getter("chi_shi_history_limit", 30, min_value=1)
+        return history[:limit]
+    def _clean_kv_dict(self, raw: Any) -> dict[str, str]:
+        if not isinstance(raw, dict):
+            return {}
+        result: dict[str, str] = {}
+        for key, value in raw.items():
+            key_s = str(key).strip()
+            val_s = str(value).strip()
+            if key_s and val_s:
+                result[key_s] = val_s
+        return result
+    def _clean_kv_list(self, raw: Any) -> list[str]:
+        values = raw if isinstance(raw, list) else [raw]
+        cleaned: list[str] = []
+        seen: set[str] = set()
+        for item in values:
+            item_s = str(item).strip()
+            if not item_s or item_s in seen:
+                continue
+            seen.add(item_s)
+            cleaned.append(item_s)
+        return cleaned
+    def _clean_kv_list_dict(self, raw: Any) -> dict[str, list[str]]:
+        if not isinstance(raw, dict):
+            return {}
+        result: dict[str, list[str]] = {}
+        for key, value in raw.items():
+            key_s = str(key).strip()
+            if not key_s:
+                continue
+            values = value if isinstance(value, list) else [value]
+            cleaned = self._clean_kv_list(values)
+            if cleaned:
+                result[key_s] = cleaned
+        return result
+    def _prepend_history_item(self, history: list[str], item: str) -> list[str]:
+        value = str(item).strip()
+        if not value:
+            return history
+        updated = [entry for entry in history if entry != value]
+        updated.insert(0, value)
+        return updated
+    def _normalize_sessions(self, raw: Any) -> list[str]:
+        values = raw if isinstance(raw, list) else [raw]
+        normalized = self._normalize_session_list(values)
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for session in normalized:
+            if session in seen:
+                continue
+            seen.add(session)
+            deduped.append(session)
+        return deduped
+    def _normalize_session(self, raw: Any) -> str:
+        normalized = self._normalize_sessions([raw])
+        if not normalized:
+            return ""
+        return normalized[0]

--- a/services/http_executor.py
+++ b/services/http_executor.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+import aiofiles
+import httpx
+from astrbot.api import logger
+
+PDF_SIGNATURE = b"%PDF-"
+PREVIEW_MAX_BYTES = 1024
+PREVIEW_CHARS = 300
+PREVIEW_CHUNK_BYTES = 256
+DOWNLOAD_CHUNK_BYTES = 1024 * 64
+
+class NonRetryableRequestError(RuntimeError):
+    pass
+
+@dataclass(frozen=True)
+class HttpRequestOptions:
+    timeout: int
+    retry: int
+
+
+@dataclass(frozen=True)
+class HttpStatusPolicy:
+    redirect_message: str
+    redirect_error: str
+    retry_message: str
+    error_message: str
+    error_prefix: str
+
+
+JSON_STATUS_POLICY = HttpStatusPolicy(
+    redirect_message="Supabase 请求被重定向，已阻止：状态码=%s 地址=%s 跳转=%s",
+    redirect_error="Supabase 请求发生未预期的重定向",
+    retry_message="HTTP 请求因状态码触发重试：状态码=%s 尝试=%s/%s 地址=%s",
+    error_message="Supabase 请求 HTTP 错误：状态码=%s 地址=%s 响应=%s",
+    error_prefix="Supabase 请求返回 HTTP 错误",
+)
+PDF_STATUS_POLICY = HttpStatusPolicy(
+    redirect_message="PDF 下载出现重定向，已阻止：状态码=%s 地址=%s 跳转=%s",
+    redirect_error="下载 PDF 时发生未预期的重定向",
+    retry_message="PDF 下载因状态码触发重试：状态码=%s 尝试=%s/%s 地址=%s",
+    error_message="PDF 下载 HTTP 错误：状态码=%s 地址=%s 响应=%s",
+    error_prefix="下载 PDF 时出现 HTTP 错误",
+)
+
+
+class HttpExecutor:
+    def __init__(
+        self,
+        *,
+        get_client: Callable[[], Awaitable[httpx.AsyncClient]],
+        backoff_sleep: Callable[[int], Awaitable[None]],
+        mask_text: Callable[[str], str],
+        mask_url: Callable[[str], str],
+    ):
+        self._get_client = get_client
+        self._backoff_sleep = backoff_sleep
+        self._mask_text = mask_text
+        self._mask_url = mask_url
+
+    async def request_json(
+        self,
+        *,
+        method: str,
+        url: str,
+        params: dict[str, Any] | None,
+        json_body: dict[str, Any] | None,
+        headers: dict[str, str],
+        options: HttpRequestOptions,
+    ) -> Any:
+        safe_url = self._mask_url(url)
+        return await self._run_with_retry(
+            retry=options.retry,
+            safe_url=safe_url,
+            retry_log_label="HTTP 请求",
+            run_attempt=lambda client, attempt, retry: self._request_json_once(
+                client=client,
+                method=method,
+                url=url,
+                params=params,
+                json_body=json_body,
+                headers=headers,
+                timeout=options.timeout,
+                safe_url=safe_url,
+                attempt=attempt,
+                retry=retry,
+            ),
+        )
+
+    async def download_pdf(
+        self,
+        *,
+        url: str,
+        target_path: Path,
+        headers: dict[str, str],
+        max_bytes: int,
+        options: HttpRequestOptions,
+    ) -> tuple[int, str]:
+        safe_url = self._mask_url(url)
+        result = await self._run_with_retry(
+            retry=options.retry,
+            safe_url=safe_url,
+            retry_log_label="PDF 下载",
+            on_attempt_error=lambda: self._remove_partial_file(target_path),
+            run_attempt=lambda client, attempt, retry: self._download_pdf_once(
+                client=client,
+                url=url,
+                target_path=target_path,
+                headers=headers,
+                max_bytes=max_bytes,
+                timeout=options.timeout,
+                safe_url=safe_url,
+                attempt=attempt,
+                retry=retry,
+            ),
+        )
+        if (not target_path.exists()) or target_path.stat().st_size <= 0:
+            raise RuntimeError("下载后的 PDF 文件不存在")
+        return result
+
+    async def _run_with_retry(
+        self,
+        *,
+        retry: int,
+        safe_url: str,
+        retry_log_label: str,
+        run_attempt: Callable[[httpx.AsyncClient, int, int], Awaitable[tuple[bool, Any]]],
+        on_attempt_error: Callable[[], None] | None = None,
+    ) -> Any:
+        client = await self._get_client()
+        last_error: Exception | None = None
+        for attempt in range(1, retry + 1):
+            try:
+                should_retry, value = await run_attempt(client, attempt, retry)
+            except Exception as exc:
+                last_error = exc
+                if on_attempt_error is not None:
+                    on_attempt_error()
+                if isinstance(exc, NonRetryableRequestError):
+                    break
+                if attempt < retry:
+                    logger.warning(
+                        "%s因异常触发重试：尝试=%s/%s 地址=%s 错误=%s",
+                        retry_log_label,
+                        attempt,
+                        retry,
+                        safe_url,
+                        self._mask_text(str(exc)),
+                    )
+                    await self._backoff_sleep(attempt)
+                    continue
+                break
+            if should_retry and attempt < retry:
+                await self._backoff_sleep(attempt)
+                continue
+            return value
+        assert last_error is not None
+        raise last_error
+
+    async def _request_json_once(self, *, client: httpx.AsyncClient, method: str, url: str, params: dict[str, Any] | None, json_body: dict[str, Any] | None, headers: dict[str, str], timeout: int, safe_url: str, attempt: int, retry: int) -> tuple[bool, Any]:
+        response = await client.request(method=method, url=url, params=params, json=json_body, headers=headers, follow_redirects=False, timeout=timeout)
+        if await self._evaluate_response(response=response, safe_url=safe_url, attempt=attempt, retry=retry, policy=JSON_STATUS_POLICY, preview_reader=self._read_loaded_preview):
+            return True, None
+        try:
+            return False, response.json()
+        except Exception:
+            logger.warning("Supabase 响应 JSON 解析失败：地址=%s 响应=%s", safe_url, self._decode_preview_bytes(response.content))
+            raise NonRetryableRequestError("Supabase 响应 JSON 解析失败")
+
+    async def _download_pdf_once(self, *, client: httpx.AsyncClient, url: str, target_path: Path, headers: dict[str, str], max_bytes: int, timeout: int, safe_url: str, attempt: int, retry: int) -> tuple[bool, tuple[int, str]]:
+        async with client.stream(method="GET", url=url, headers=headers, follow_redirects=False, timeout=timeout) as response:
+            status_code = response.status_code
+            content_type = str(response.headers.get("content-type", ""))
+            if await self._evaluate_response(response=response, safe_url=safe_url, attempt=attempt, retry=retry, policy=PDF_STATUS_POLICY, preview_reader=self._read_response_preview):
+                return True, (status_code, content_type)
+            if "application/pdf" not in content_type.lower():
+                logger.warning("PDF 响应的内容类型不是 application/pdf：%s（将继续校验文件头）", content_type)
+            await self._stream_pdf_to_file(response=response, target_path=target_path, max_bytes=max_bytes)
+            return False, (status_code, content_type)
+
+    async def _evaluate_response(
+        self,
+        *,
+        response: httpx.Response,
+        safe_url: str,
+        attempt: int,
+        retry: int,
+        policy: HttpStatusPolicy,
+        preview_reader: Callable[[httpx.Response], Awaitable[str]],
+    ) -> bool:
+        status_code = response.status_code
+        if 300 <= status_code < 400:
+            self._raise_redirect_error(status_code, safe_url, response.headers.get("location", ""), policy.redirect_message, policy.redirect_error)
+        if status_code >= 500 and attempt < retry:
+            logger.warning(policy.retry_message, status_code, attempt, retry, safe_url)
+            return True
+        if status_code >= 400:
+            logger.warning(policy.error_message, status_code, safe_url, await preview_reader(response))
+            raise NonRetryableRequestError(f"{policy.error_prefix}：{status_code}")
+        return False
+
+    async def _read_loaded_preview(self, response: httpx.Response) -> str:
+        return self._decode_preview_bytes(response.content)
+
+    async def _read_response_preview(self, response: httpx.Response) -> str:
+        preview = bytearray()
+        async for chunk in response.aiter_bytes(chunk_size=PREVIEW_CHUNK_BYTES):
+            if not chunk:
+                continue
+            remaining = PREVIEW_MAX_BYTES - len(preview)
+            if remaining <= 0:
+                break
+            preview.extend(chunk[:remaining])
+            if len(preview) >= PREVIEW_MAX_BYTES:
+                break
+        return self._decode_preview_bytes(preview)
+
+    async def _stream_pdf_to_file(
+        self,
+        *,
+        response: httpx.Response,
+        target_path: Path,
+        max_bytes: int,
+    ) -> None:
+        header_preview = bytearray()
+        downloaded_bytes = 0
+        async with aiofiles.open(target_path, "wb") as fp:
+            async for chunk in response.aiter_bytes(chunk_size=DOWNLOAD_CHUNK_BYTES):
+                if not chunk:
+                    continue
+                downloaded_bytes += len(chunk)
+                if downloaded_bytes > max_bytes:
+                    raise NonRetryableRequestError(
+                        f"PDF 文件过大：{downloaded_bytes} 字节，超过配置上限 {max_bytes} 字节",
+                    )
+                if len(header_preview) < len(PDF_SIGNATURE):
+                    missing = len(PDF_SIGNATURE) - len(header_preview)
+                    header_preview.extend(chunk[:missing])
+                    if len(header_preview) >= len(PDF_SIGNATURE):
+                        if bytes(header_preview[: len(PDF_SIGNATURE)]) != PDF_SIGNATURE:
+                            raise NonRetryableRequestError("下载的文件不是有效的 PDF")
+                await fp.write(chunk)
+        if bytes(header_preview[: len(PDF_SIGNATURE)]) != PDF_SIGNATURE:
+            raise NonRetryableRequestError("下载的文件不是有效的 PDF")
+
+    def _decode_preview_bytes(self, data: bytes | bytearray) -> str:
+        preview_bytes = bytes(data[:PREVIEW_MAX_BYTES])
+        text = preview_bytes[:PREVIEW_CHARS].decode("utf-8", errors="replace")
+        return self._mask_text(text)
+
+    def _raise_redirect_error(self, status_code: int, safe_url: str, location: Any, message: str, error_text: str) -> None:
+        masked_location = self._mask_url(str(location).strip())
+        logger.warning(message, status_code, safe_url, masked_location or "<缺失>")
+        raise NonRetryableRequestError(error_text)
+
+    def _remove_partial_file(self, target_path: Path) -> None:
+        try:
+            target_path.unlink(missing_ok=True)
+        except Exception:
+            logger.warning("删除未完成的下载文件失败：%s", str(target_path), exc_info=True)

--- a/services/message_sink.py
+++ b/services/message_sink.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from astrbot.api import logger
+from astrbot.api.event import AstrMessageEvent, MessageEventResult
+from astrbot.core.platform.message_session import MessageSesion
+
+from .push_chain_builder import ONEBOT_ADAPTER_NAME, ONEBOT_MERGE_FORWARD_MESSAGE_TYPES
+
+
+class MessageSink(Protocol):
+    async def send(self, chain: MessageEventResult) -> bool:
+        ...
+
+
+@dataclass(frozen=True)
+class EventMessageSink:
+    event: AstrMessageEvent
+
+    async def send(self, chain: MessageEventResult) -> bool:
+        await self.event.send(chain)
+        return True
+
+
+@dataclass(frozen=True)
+class SessionMessageSink:
+    context: Any
+    session: str
+
+    async def send(self, chain: MessageEventResult) -> bool:
+        return bool(await self.context.send_message(self.session, chain))
+
+
+class OneBotPlatformResolver:
+    def __init__(self, cfg_bool_getter):
+        self._cfg_bool = cfg_bool_getter
+        self._self_id_cache: dict[str, str] = {}
+
+    def resolve_merge_forward_platform(self, context: Any, session: str) -> Any | None:
+        if not self._cfg_bool("send_merge_forward", False):
+            return None
+        try:
+            message_session = MessageSesion.from_str(session)
+        except Exception:
+            logger.warning("无法解析主动消息会话，回退普通消息：%s", session, exc_info=True)
+            return None
+        if message_session.message_type not in ONEBOT_MERGE_FORWARD_MESSAGE_TYPES:
+            return None
+        platform = self._find_platform_by_id(context, message_session.platform_name)
+        if platform is None:
+            logger.warning("未找到目标平台实例，回退普通消息：%s", session)
+            return None
+        if str(platform.meta().name) != ONEBOT_ADAPTER_NAME:
+            return None
+        return platform
+
+    def resolve_platform_name(self, context: Any, session: str) -> str:
+        try:
+            message_session = MessageSesion.from_str(session)
+        except Exception:
+            return ""
+        platform = self._find_platform_by_id(context, message_session.platform_name)
+        if platform is None:
+            return ""
+        return str(platform.meta().name)
+
+    async def get_platform_self_id(self, platform: Any) -> str:
+        platform_meta = platform.meta()
+        platform_id = str(getattr(platform_meta, "id", "")).strip()
+        cached_self_id = self._self_id_cache.get(platform_id, "")
+        if cached_self_id:
+            return cached_self_id
+        bot = getattr(platform, "bot", None)
+        call_action = getattr(bot, "call_action", None)
+        if not callable(call_action):
+            return ""
+        try:
+            login_info = await call_action("get_login_info")
+        except Exception:
+            logger.warning("获取 OneBot 登录信息失败：平台=%s", platform_id, exc_info=True)
+            return ""
+        user_id = self._extract_user_id(login_info)
+        if user_id:
+            self._self_id_cache[platform_id] = user_id
+        return user_id
+
+    def _find_platform_by_id(self, context: Any, platform_id: str) -> Any | None:
+        platform_manager = getattr(context, "platform_manager", None)
+        if platform_manager is None:
+            return None
+        get_insts = getattr(platform_manager, "get_insts", None)
+        platforms = list(get_insts()) if callable(get_insts) else list(getattr(platform_manager, "platform_insts", []))
+        for platform in platforms:
+            meta = getattr(platform, "meta", None)
+            if not callable(meta):
+                continue
+            try:
+                platform_meta = meta()
+            except Exception:
+                continue
+            if str(getattr(platform_meta, "id", "")) == platform_id:
+                return platform
+        return None
+
+    def _extract_user_id(self, login_info: Any) -> str:
+        if not isinstance(login_info, dict):
+            return ""
+        direct_user_id = str(login_info.get("user_id", "")).strip()
+        if direct_user_id:
+            return direct_user_id
+        data = login_info.get("data")
+        if not isinstance(data, dict):
+            return ""
+        return str(data.get("user_id", "")).strip()

--- a/services/models.py
+++ b/services/models.py
@@ -78,8 +78,6 @@ class RunBatch:
     paper_id: str = ""
     detail_url: str = ""
     targets: list[str] = field(default_factory=list)
-    sent_history_by_target: dict[str, list[str]] = field(default_factory=dict)
-    sent_history_lookup_by_target: dict[str, set[str]] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -88,14 +86,6 @@ class RunBatch:
             "paper_id": self.paper_id,
             "detail_url": self.detail_url,
             "targets": list(self.targets),
-            "sent_history_by_target": {
-                str(key): list(value)
-                for key, value in self.sent_history_by_target.items()
-            },
-            "sent_history_lookup_by_target": {
-                str(key): list(value)
-                for key, value in self.sent_history_lookup_by_target.items()
-            },
         }
 
     @classmethod
@@ -108,14 +98,6 @@ class RunBatch:
             paper_id=str(payload.get("paper_id", "")),
             detail_url=str(payload.get("detail_url", "")),
             targets=[str(item) for item in payload.get("targets", []) or []],
-            sent_history_by_target={
-                str(key): [str(item) for item in (values or [])]
-                for key, values in dict(payload.get("sent_history_by_target", {}) or {}).items()
-            },
-            sent_history_lookup_by_target={
-                str(key): {str(item) for item in (values or [])}
-                for key, values in dict(payload.get("sent_history_lookup_by_target", {}) or {}).items()
-            },
         )
 
 

--- a/services/models.py
+++ b/services/models.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+
+class RunStatus(StrEnum):
+    SUCCESS = "success"
+    PARTIAL = "partial"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    UNKNOWN = "unknown"
+
+
+class RunReason(StrEnum):
+    RUN_IN_PROGRESS = "RUN_IN_PROGRESS"
+    NO_TARGET_SESSION_CONFIGURED = "NO_TARGET_SESSION_CONFIGURED"
+    FETCH_LATEST_FAILED = "FETCH_LATEST_FAILED"
+    ALREADY_DELIVERED = "ALREADY_DELIVERED"
+    LATEST_NOT_FOUND = "LATEST_NOT_FOUND"
+    EMPTY_PAPER_ID = "EMPTY_PAPER_ID"
+    DELIVERY_STATE_WRITE_FAILED = "DELIVERY_STATE_WRITE_FAILED"
+    PREPARE_ASSETS_FAILED = "PREPARE_ASSETS_FAILED"
+    PUSHED_SUCCESSFULLY = "PUSHED_SUCCESSFULLY"
+    PUSHED_PARTIALLY = "PUSHED_PARTIALLY"
+    ALL_SENDS_FAILED = "ALL_SENDS_FAILED"
+    UNKNOWN = "UNKNOWN"
+
+
+def _coerce_status(value: Any, default: RunStatus = RunStatus.UNKNOWN) -> RunStatus:
+    if isinstance(value, RunStatus):
+        return value
+    text = str(value or "").strip().lower()
+    if not text:
+        return default
+    try:
+        return RunStatus(text)
+    except ValueError:
+        return default
+
+
+def _coerce_reason(value: Any, default: RunReason = RunReason.UNKNOWN) -> RunReason:
+    if isinstance(value, RunReason):
+        return value
+    text = str(value or "").strip()
+    if not text:
+        return default
+    try:
+        return RunReason(text)
+    except ValueError:
+        return default
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+
+    text = str(value).strip().lower()
+    if not text:
+        return default
+    if text in {"1", "true", "t", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "f", "no", "n", "off"}:
+        return False
+    return default
+
+
+@dataclass(slots=True)
+class RunBatch:
+    zone: str = ""
+    latest: dict[str, Any] = field(default_factory=dict)
+    paper_id: str = ""
+    detail_url: str = ""
+    targets: list[str] = field(default_factory=list)
+    sent_history_by_target: dict[str, list[str]] = field(default_factory=dict)
+    sent_history_lookup_by_target: dict[str, set[str]] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "zone": self.zone,
+            "latest": dict(self.latest),
+            "paper_id": self.paper_id,
+            "detail_url": self.detail_url,
+            "targets": list(self.targets),
+            "sent_history_by_target": {
+                str(key): list(value)
+                for key, value in self.sent_history_by_target.items()
+            },
+            "sent_history_lookup_by_target": {
+                str(key): list(value)
+                for key, value in self.sent_history_lookup_by_target.items()
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | RunBatch) -> RunBatch:
+        if isinstance(payload, RunBatch):
+            return payload
+        return cls(
+            zone=str(payload.get("zone", "")),
+            latest=dict(payload.get("latest", {}) or {}),
+            paper_id=str(payload.get("paper_id", "")),
+            detail_url=str(payload.get("detail_url", "")),
+            targets=[str(item) for item in payload.get("targets", []) or []],
+            sent_history_by_target={
+                str(key): [str(item) for item in (values or [])]
+                for key, values in dict(payload.get("sent_history_by_target", {}) or {}).items()
+            },
+            sent_history_lookup_by_target={
+                str(key): {str(item) for item in (values or [])}
+                for key, values in dict(payload.get("sent_history_lookup_by_target", {}) or {}).items()
+            },
+        )
+
+
+@dataclass(slots=True)
+class RunBatchReport:
+    status: RunStatus = RunStatus.FAILED
+    reason_code: RunReason = RunReason.UNKNOWN
+    zone: str = ""
+    paper_id: str = ""
+    detail_url: str = ""
+    sent_ok: int = 0
+    sent_total: int = 0
+    debug_reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "reason_code": self.reason_code.value,
+            "zone": self.zone,
+            "paper_id": self.paper_id,
+            "detail_url": self.detail_url,
+            "sent_ok": self.sent_ok,
+            "sent_total": self.sent_total,
+            "debug_reason": self.debug_reason,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | RunBatchReport) -> RunBatchReport:
+        if isinstance(payload, RunBatchReport):
+            return payload
+        return cls(
+            status=_coerce_status(payload.get("status"), default=RunStatus.FAILED),
+            reason_code=_coerce_reason(payload.get("reason_code"), default=RunReason.UNKNOWN),
+            zone=str(payload.get("zone", "")),
+            paper_id=str(payload.get("paper_id", "")),
+            detail_url=str(payload.get("detail_url", "")),
+            sent_ok=int(payload.get("sent_ok", 0) or 0),
+            sent_total=int(payload.get("sent_total", 0) or 0),
+            debug_reason=str(payload.get("debug_reason", "")),
+        )
+
+
+@dataclass(slots=True)
+class RunReport:
+    status: RunStatus = RunStatus.FAILED
+    source: str = ""
+    zone: str = ""
+    requested_zone: str = ""
+    force: bool = False
+    paper_id: str = ""
+    detail_url: str = ""
+    sent_ok: int = 0
+    sent_total: int = 0
+    reason_code: RunReason = RunReason.UNKNOWN
+    debug_reason: str = ""
+    latest_only: bool = False
+    batches: list[RunBatchReport] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "source": self.source,
+            "zone": self.zone,
+            "requested_zone": self.requested_zone,
+            "force": self.force,
+            "paper_id": self.paper_id,
+            "detail_url": self.detail_url,
+            "sent_ok": self.sent_ok,
+            "sent_total": self.sent_total,
+            "reason_code": self.reason_code.value,
+            "debug_reason": self.debug_reason,
+            "latest_only": self.latest_only,
+            "batches": [batch.to_dict() for batch in self.batches],
+            "warnings": list(self.warnings),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | RunReport) -> RunReport:
+        if isinstance(payload, RunReport):
+            return payload
+        return cls(
+            status=_coerce_status(payload.get("status"), default=RunStatus.FAILED),
+            source=str(payload.get("source", "")),
+            zone=str(payload.get("zone", "")),
+            requested_zone=str(payload.get("requested_zone", "")),
+            force=_coerce_bool(payload.get("force"), default=False),
+            paper_id=str(payload.get("paper_id", "")),
+            detail_url=str(payload.get("detail_url", "")),
+            sent_ok=int(payload.get("sent_ok", 0) or 0),
+            sent_total=int(payload.get("sent_total", 0) or 0),
+            reason_code=_coerce_reason(payload.get("reason_code"), default=RunReason.UNKNOWN),
+            debug_reason=str(payload.get("debug_reason", "")),
+            latest_only=_coerce_bool(payload.get("latest_only"), default=False),
+            batches=[
+                RunBatchReport.from_dict(item)
+                for item in payload.get("batches", []) or []
+            ],
+            warnings=[str(item) for item in payload.get("warnings", []) or []],
+        )
+
+
+@dataclass(slots=True)
+class PushRequest:
+    targets: list[str] = field(default_factory=list)
+    text: str = ""
+    png_file: Path | None = None
+    pdf_file: Path | None = None
+    pdf_url: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "targets": list(self.targets),
+            "text": self.text,
+            "png_file": str(self.png_file) if self.png_file else "",
+            "pdf_file": str(self.pdf_file) if self.pdf_file else "",
+            "pdf_url": self.pdf_url,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | PushRequest) -> PushRequest:
+        if isinstance(payload, PushRequest):
+            return payload
+        png_file = str(payload.get("png_file", "")).strip()
+        pdf_file = str(payload.get("pdf_file", "")).strip()
+        return cls(
+            targets=[str(item) for item in payload.get("targets", []) or []],
+            text=str(payload.get("text", "")),
+            png_file=Path(png_file) if png_file else None,
+            pdf_file=Path(pdf_file) if pdf_file else None,
+            pdf_url=str(payload.get("pdf_url", "")),
+        )

--- a/services/models.py
+++ b/services/models.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import StrEnum
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
 
-class RunStatus(StrEnum):
+class RunStatus(str, Enum):
+    __str__ = str.__str__
+
     SUCCESS = "success"
     PARTIAL = "partial"
     FAILED = "failed"
@@ -14,7 +16,9 @@ class RunStatus(StrEnum):
     UNKNOWN = "unknown"
 
 
-class RunReason(StrEnum):
+class RunReason(str, Enum):
+    __str__ = str.__str__
+
     RUN_IN_PROGRESS = "RUN_IN_PROGRESS"
     NO_TARGET_SESSION_CONFIGURED = "NO_TARGET_SESSION_CONFIGURED"
     FETCH_LATEST_FAILED = "FETCH_LATEST_FAILED"

--- a/services/push_chain_builder.py
+++ b/services/push_chain_builder.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from astrbot.api.event import MessageEventResult
+from astrbot.api.message_components import File, Image, Node, Nodes, Plain
+from astrbot.core.platform.message_type import MessageType
+
+
+FORWARD_SENDER_NAME = "S.H.I.T Journal"
+ONEBOT_ADAPTER_NAME = "aiocqhttp"
+SATORI_ADAPTER_NAME = "satori"
+LARK_ADAPTER_NAME = "lark"
+LOCAL_PDF_FILE_ADAPTERS = frozenset({
+    SATORI_ADAPTER_NAME,
+    LARK_ADAPTER_NAME,
+})
+ONEBOT_MERGE_FORWARD_MESSAGE_TYPES = frozenset({
+    MessageType.GROUP_MESSAGE,
+    MessageType.FRIEND_MESSAGE,
+})
+
+
+class PushChainBuilder:
+    def __init__(self, cfg_bool_getter: Callable[[str, bool], bool]):
+        self._cfg_bool = cfg_bool_getter
+
+    def build_standard_chain(
+        self,
+        *,
+        adapter_name: str,
+        text: str,
+        png_file: Path,
+        pdf_file: Path,
+        pdf_url: str,
+    ) -> MessageEventResult:
+        chain = MessageEventResult()
+        chain.chain.extend(
+            self._build_standard_components(
+                adapter_name=adapter_name,
+                text=text,
+                png_file=png_file,
+                pdf_file=pdf_file,
+                pdf_url=pdf_url,
+            ),
+        )
+        return chain
+
+    def build_standard_chains(
+        self,
+        *,
+        adapter_name: str,
+        text: str,
+        png_file: Path,
+        pdf_file: Path,
+        pdf_url: str,
+    ) -> list[MessageEventResult]:
+        if not self._should_split_standard_file_send(adapter_name):
+            return [
+                self.build_standard_chain(
+                    adapter_name=adapter_name,
+                    text=text,
+                    png_file=png_file,
+                    pdf_file=pdf_file,
+                    pdf_url=pdf_url,
+                ),
+            ]
+        chains = [self._build_text_image_chain(text=text, png_file=png_file)]
+        pdf_chain = self.build_pdf_only_chain(
+            adapter_name=adapter_name,
+            pdf_file=pdf_file,
+            pdf_url=pdf_url,
+        )
+        if pdf_chain is not None:
+            chains.append(pdf_chain)
+        return chains
+
+    def build_merge_forward_chain(
+        self,
+        *,
+        adapter_name: str,
+        text: str,
+        png_file: Path,
+        pdf_file: Path,
+        pdf_url: str,
+        sender_uin: str,
+        include_pdf: bool,
+    ) -> MessageEventResult:
+        nodes = [
+            Node(
+                name=FORWARD_SENDER_NAME,
+                uin=str(sender_uin),
+                content=[Plain(text), Image.fromFileSystem(str(png_file))],
+            ),
+        ]
+        if include_pdf:
+            pdf_component = self._build_pdf_component(
+                adapter_name=adapter_name,
+                pdf_file=pdf_file,
+                pdf_url=pdf_url,
+            )
+            if pdf_component is not None:
+                nodes.append(
+                    Node(
+                        name=FORWARD_SENDER_NAME,
+                        uin=str(sender_uin),
+                        content=[pdf_component],
+                    ),
+                )
+        chain = MessageEventResult()
+        chain.chain.append(Nodes(nodes=nodes))
+        return chain
+
+    def build_pdf_only_chain(
+        self,
+        *,
+        adapter_name: str,
+        pdf_file: Path,
+        pdf_url: str,
+    ) -> MessageEventResult | None:
+        pdf_component = self._build_pdf_component(
+            adapter_name=adapter_name,
+            pdf_file=pdf_file,
+            pdf_url=pdf_url,
+        )
+        if pdf_component is None:
+            return None
+        chain = MessageEventResult()
+        chain.chain.append(pdf_component)
+        return chain
+
+    def _build_standard_components(
+        self,
+        *,
+        adapter_name: str,
+        text: str,
+        png_file: Path,
+        pdf_file: Path,
+        pdf_url: str,
+    ) -> list[Any]:
+        components: list[Any] = [Plain(text), Image.fromFileSystem(str(png_file))]
+        pdf_component = self._build_pdf_component(
+            adapter_name=adapter_name,
+            pdf_file=pdf_file,
+            pdf_url=pdf_url,
+        )
+        if pdf_component is not None:
+            components.append(pdf_component)
+        return components
+
+    def _build_pdf_component(
+        self,
+        *,
+        adapter_name: str,
+        pdf_file: Path,
+        pdf_url: str,
+    ) -> File | None:
+        if not self._cfg_bool("send_pdf", False):
+            return None
+        if self._should_use_pdf_url(adapter_name) and pdf_url:
+            return File(name=pdf_file.name, url=pdf_url)
+        return File(name=pdf_file.name, file=str(pdf_file))
+
+    def _build_text_image_chain(self, *, text: str, png_file: Path) -> MessageEventResult:
+        chain = MessageEventResult()
+        chain.chain.extend([Plain(text), Image.fromFileSystem(str(png_file))])
+        return chain
+
+    def _should_use_pdf_url(self, adapter_name: str) -> bool:
+        return str(adapter_name).strip() not in LOCAL_PDF_FILE_ADAPTERS
+
+    def _should_split_standard_file_send(self, adapter_name: str) -> bool:
+        return adapter_name == ONEBOT_ADAPTER_NAME and self._cfg_bool("send_pdf", False)

--- a/services/push_message_service.py
+++ b/services/push_message_service.py
@@ -1,35 +1,30 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, MessageEventResult
-from astrbot.api.message_components import File, Image, Node, Nodes, Plain
-from astrbot.core.platform.message_session import MessageSesion
-from astrbot.core.platform.message_type import MessageType
 
+from .message_sink import EventMessageSink, MessageSink, OneBotPlatformResolver, SessionMessageSink
+from .push_chain_builder import ONEBOT_ADAPTER_NAME, PushChainBuilder
 from .session_message import is_group_message_session, is_private_message_session
 
 
-FORWARD_SENDER_NAME = "S.H.I.T Journal"
-ONEBOT_ADAPTER_NAME = "aiocqhttp"
-SATORI_ADAPTER_NAME = "satori"
-LARK_ADAPTER_NAME = "lark"
-LOCAL_PDF_FILE_ADAPTERS = frozenset({
-    SATORI_ADAPTER_NAME,
-    LARK_ADAPTER_NAME,
-})
-ONEBOT_MERGE_FORWARD_MESSAGE_TYPES = frozenset({
-    MessageType.GROUP_MESSAGE,
-    MessageType.FRIEND_MESSAGE,
-})
+@dataclass(frozen=True)
+class PushPayload:
+    text: str
+    png_file: Path
+    pdf_file: Path
+    pdf_url: str
 
 
 class PushMessageService:
     def __init__(self, cfg_bool_getter: Callable[[str, bool], bool]):
         self._cfg_bool = cfg_bool_getter
-        self._self_id_cache: dict[str, str] = {}
+        self._chains = PushChainBuilder(cfg_bool_getter=cfg_bool_getter)
+        self._platforms = OneBotPlatformResolver(cfg_bool_getter=cfg_bool_getter)
 
     def build_standard_chain(
         self,
@@ -39,17 +34,14 @@ class PushMessageService:
         pdf_file: Path,
         pdf_url: str,
     ) -> MessageEventResult:
-        chain = MessageEventResult()
-        chain.chain.extend(
-            self._build_push_components(
-                adapter_name=adapter_name,
-                text=text,
-                png_file=png_file,
-                pdf_file=pdf_file,
-                pdf_url=pdf_url,
-            ),
+        payload = PushPayload(text=text, png_file=png_file, pdf_file=pdf_file, pdf_url=pdf_url)
+        return self._chains.build_standard_chain(
+            adapter_name=adapter_name,
+            text=payload.text,
+            png_file=payload.png_file,
+            pdf_file=payload.pdf_file,
+            pdf_url=payload.pdf_url,
         )
-        return chain
 
     def build_merge_forward_chain(
         self,
@@ -62,33 +54,16 @@ class PushMessageService:
         *,
         include_pdf: bool = False,
     ) -> MessageEventResult:
-        chain = MessageEventResult()
-        nodes = [
-            Node(
-                name=FORWARD_SENDER_NAME,
-                uin=str(sender_uin),
-                content=[
-                    Plain(text),
-                    Image.fromFileSystem(str(png_file)),
-                ],
-            ),
-        ]
-        if include_pdf:
-            file_component = self._build_pdf_component(
-                adapter_name=adapter_name,
-                pdf_file=pdf_file,
-                pdf_url=pdf_url,
-            )
-            if file_component is not None:
-                nodes.append(
-                    Node(
-                        name=FORWARD_SENDER_NAME,
-                        uin=str(sender_uin),
-                        content=[file_component],
-                    ),
-                )
-        chain.chain.append(Nodes(nodes=nodes))
-        return chain
+        payload = PushPayload(text=text, png_file=png_file, pdf_file=pdf_file, pdf_url=pdf_url)
+        return self._chains.build_merge_forward_chain(
+            adapter_name=adapter_name,
+            text=payload.text,
+            png_file=payload.png_file,
+            pdf_file=payload.pdf_file,
+            pdf_url=payload.pdf_url,
+            sender_uin=sender_uin,
+            include_pdf=include_pdf,
+        )
 
     async def send_event_push(
         self,
@@ -99,48 +74,31 @@ class PushMessageService:
         pdf_url: str,
     ) -> None:
         adapter_name = str(event.get_platform_name()).strip()
+        payload = PushPayload(text=text, png_file=png_file, pdf_file=pdf_file, pdf_url=pdf_url)
+        sink = EventMessageSink(event=event)
         if not self._should_try_merge_forward_for_event(event):
-            await self._send_standard_event_push(
-                event=event,
-                adapter_name=adapter_name,
-                text=text,
-                png_file=png_file,
-                pdf_file=pdf_file,
-                pdf_url=pdf_url,
-            )
+            await self._send_standard(sink=sink, adapter_name=adapter_name, payload=payload)
             return
-
         sender_uin = str(event.get_self_id()).strip()
         if not sender_uin:
             logger.warning("事件发送无法获取机器人自身 ID，回退普通消息。")
-            await self._send_standard_event_push(
-                event=event,
-                adapter_name=adapter_name,
-                text=text,
-                png_file=png_file,
-                pdf_file=pdf_file,
-                pdf_url=pdf_url,
-            )
+            await self._send_standard(sink=sink, adapter_name=adapter_name, payload=payload)
             return
-
         embed_pdf_in_merge = self._should_embed_pdf_in_event_forward(event)
-        merge_chain = self.build_merge_forward_chain(
+        merge_chain = self._chains.build_merge_forward_chain(
             adapter_name=adapter_name,
-            text=text,
-            png_file=png_file,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
+            text=payload.text,
+            png_file=payload.png_file,
+            pdf_file=payload.pdf_file,
+            pdf_url=payload.pdf_url,
             sender_uin=sender_uin,
             include_pdf=embed_pdf_in_merge,
         )
         await self._send_event_with_fallback(
-            event=event,
+            sink=sink,
             adapter_name=adapter_name,
+            payload=payload,
             merge_chain=merge_chain,
-            text=text,
-            png_file=png_file,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
             send_pdf_tail=not embed_pdf_in_merge,
         )
 
@@ -153,92 +111,132 @@ class PushMessageService:
         pdf_file: Path,
         pdf_url: str,
     ) -> bool:
-        adapter_name = self._resolve_platform_name(context, session)
-        platform = self._resolve_merge_forward_platform(context, session)
+        adapter_name = self._platforms.resolve_platform_name(context, session)
+        payload = PushPayload(text=text, png_file=png_file, pdf_file=pdf_file, pdf_url=pdf_url)
+        sink = SessionMessageSink(context=context, session=session)
+        platform = self._platforms.resolve_merge_forward_platform(context, session)
         if platform is None:
-            return await self._send_standard_session_push(
-                context=context,
-                session=session,
-                adapter_name=adapter_name,
-                text=text,
-                png_file=png_file,
-                pdf_file=pdf_file,
-                pdf_url=pdf_url,
-            )
-
-        sender_uin = await self._get_platform_self_id(platform)
+            return await self._send_standard(sink=sink, adapter_name=adapter_name, payload=payload)
+        sender_uin = await self._platforms.get_platform_self_id(platform)
         if not sender_uin:
             logger.warning("主动发送无法获取机器人自身 ID，回退普通消息：会话=%s", session)
-            return await self._send_standard_session_push(
-                context=context,
-                session=session,
-                adapter_name=adapter_name,
-                text=text,
-                png_file=png_file,
-                pdf_file=pdf_file,
-                pdf_url=pdf_url,
-            )
-
+            return await self._send_standard(sink=sink, adapter_name=adapter_name, payload=payload)
         embed_pdf_in_merge = self._should_embed_pdf_in_session_forward(session)
-        merge_chain = self.build_merge_forward_chain(
+        merge_chain = self._chains.build_merge_forward_chain(
             adapter_name=adapter_name,
-            text=text,
-            png_file=png_file,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
+            text=payload.text,
+            png_file=payload.png_file,
+            pdf_file=payload.pdf_file,
+            pdf_url=payload.pdf_url,
             sender_uin=sender_uin,
             include_pdf=embed_pdf_in_merge,
         )
         return await self._send_session_with_fallback(
-            context=context,
+            sink=sink,
             session=session,
             adapter_name=adapter_name,
+            payload=payload,
             merge_chain=merge_chain,
-            text=text,
-            png_file=png_file,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
             send_pdf_tail=not embed_pdf_in_merge,
         )
 
-    def _build_push_components(
+    async def _send_event_with_fallback(
         self,
         *,
+        sink: MessageSink,
         adapter_name: str,
-        text: str,
-        png_file: Path,
-        pdf_file: Path,
-        pdf_url: str,
-    ) -> list[Any]:
-        components: list[Any] = [
-            Plain(text),
-            Image.fromFileSystem(str(png_file)),
-        ]
-        file_component = self._build_pdf_component(
+        payload: PushPayload,
+        merge_chain: MessageEventResult,
+        send_pdf_tail: bool,
+    ) -> None:
+        try:
+            await sink.send(merge_chain)
+        except Exception:
+            logger.warning("合并转发发送失败，回退普通消息。", exc_info=True)
+            await self._send_standard(sink=sink, adapter_name=adapter_name, payload=payload)
+            return
+        if send_pdf_tail:
+            await self._send_pdf_tail(
+                sink=sink,
+                adapter_name=adapter_name,
+                payload=payload,
+                exception_message="合并转发尾部 PDF 发送异常，但主体消息已发送成功。",
+                failed_message=None,
+            )
+
+    async def _send_session_with_fallback(
+        self,
+        *,
+        sink: MessageSink,
+        session: str,
+        adapter_name: str,
+        payload: PushPayload,
+        merge_chain: MessageEventResult,
+        send_pdf_tail: bool,
+    ) -> bool:
+        try:
+            merge_ok = await sink.send(merge_chain)
+            if not merge_ok:
+                logger.warning("合并转发发送返回失败，回退普通消息：会话=%s", session)
+                return await self._send_standard(sink=sink, adapter_name=adapter_name, payload=payload)
+        except Exception:
+            logger.warning("合并转发发送异常，回退普通消息：会话=%s", session, exc_info=True)
+            return await self._send_standard(sink=sink, adapter_name=adapter_name, payload=payload)
+        if send_pdf_tail:
+            return await self._send_pdf_tail(
+                sink=sink,
+                adapter_name=adapter_name,
+                payload=payload,
+                exception_message=f"合并转发尾部 PDF 发送异常，但主体消息已发送成功：会话={session}",
+                failed_message=f"合并转发尾部 PDF 发送失败，但主体消息已发送成功：会话={session}",
+            )
+        return True
+
+    async def _send_standard(
+        self,
+        *,
+        sink: MessageSink,
+        adapter_name: str,
+        payload: PushPayload,
+    ) -> bool:
+        sent_ok = True
+        for chain in self._chains.build_standard_chains(
             adapter_name=adapter_name,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
-        )
-        if file_component is not None:
-            components.append(file_component)
-        return components
+            text=payload.text,
+            png_file=payload.png_file,
+            pdf_file=payload.pdf_file,
+            pdf_url=payload.pdf_url,
+        ):
+            if not await sink.send(chain):
+                sent_ok = False
+        return sent_ok
 
-    def _build_pdf_component(
+    async def _send_pdf_tail(
         self,
         *,
+        sink: MessageSink,
         adapter_name: str,
-        pdf_file: Path,
-        pdf_url: str,
-    ) -> File | None:
-        if not self._cfg_bool("send_pdf", False):
-            return None
-        if self._should_use_pdf_url(adapter_name) and pdf_url:
-            return File(name=pdf_file.name, url=pdf_url)
-        return File(name=pdf_file.name, file=str(pdf_file))
-
-    def _should_use_pdf_url(self, adapter_name: str) -> bool:
-        normalized_adapter_name = str(adapter_name).strip()
-        return normalized_adapter_name not in LOCAL_PDF_FILE_ADAPTERS
+        payload: PushPayload,
+        exception_message: str,
+        failed_message: str | None,
+    ) -> bool:
+        chain = self._chains.build_pdf_only_chain(
+            adapter_name=adapter_name,
+            pdf_file=payload.pdf_file,
+            pdf_url=payload.pdf_url,
+        )
+        if chain is None:
+            return True
+        try:
+            tail_ok = await sink.send(chain)
+        except Exception:
+            logger.warning(exception_message, exc_info=True)
+            return False
+        if not tail_ok:
+            if failed_message:
+                logger.warning(failed_message)
+            return False
+        return True
 
     def _should_try_merge_forward_for_event(self, event: AstrMessageEvent) -> bool:
         if not self._cfg_bool("send_merge_forward", False):
@@ -256,320 +254,3 @@ class PushMessageService:
     def _is_onebot_private_event(self, event: AstrMessageEvent) -> bool:
         session = str(getattr(event, "unified_msg_origin", "")).strip()
         return is_private_message_session(session)
-
-    def _resolve_merge_forward_platform(self, context: Any, session: str) -> Any | None:
-        if not self._cfg_bool("send_merge_forward", False):
-            return None
-
-        try:
-            message_session = MessageSesion.from_str(session)
-        except Exception:
-            logger.warning("无法解析主动消息会话，回退普通消息：%s", session, exc_info=True)
-            return None
-
-        if message_session.message_type not in ONEBOT_MERGE_FORWARD_MESSAGE_TYPES:
-            return None
-
-        platform = self._find_platform_by_id(context, message_session.platform_name)
-        if platform is None:
-            logger.warning("未找到目标平台实例，回退普通消息：%s", session)
-            return None
-        if str(platform.meta().name) != ONEBOT_ADAPTER_NAME:
-            return None
-        return platform
-
-    def _find_platform_by_id(self, context: Any, platform_id: str) -> Any | None:
-        platform_manager = getattr(context, "platform_manager", None)
-        if platform_manager is None:
-            return None
-
-        get_insts = getattr(platform_manager, "get_insts", None)
-        if callable(get_insts):
-            platforms = list(get_insts())
-        else:
-            platforms = list(getattr(platform_manager, "platform_insts", []))
-
-        for platform in platforms:
-            meta = getattr(platform, "meta", None)
-            if not callable(meta):
-                continue
-            try:
-                platform_meta = meta()
-            except Exception:
-                continue
-            if str(getattr(platform_meta, "id", "")) == platform_id:
-                return platform
-        return None
-
-    def _resolve_platform_name(self, context: Any, session: str) -> str:
-        try:
-            message_session = MessageSesion.from_str(session)
-        except Exception:
-            return ""
-        platform = self._find_platform_by_id(context, message_session.platform_name)
-        if platform is None:
-            return ""
-        return str(platform.meta().name)
-
-    async def _send_event_with_fallback(
-        self,
-        event: AstrMessageEvent,
-        adapter_name: str,
-        merge_chain: MessageEventResult,
-        text: str,
-        png_file: Path,
-        pdf_file: Path,
-        pdf_url: str,
-        send_pdf_tail: bool,
-    ) -> None:
-        try:
-            await event.send(merge_chain)
-        except Exception:
-            logger.warning("合并转发发送失败，回退普通消息。", exc_info=True)
-            await self._send_standard_event_push(
-                event=event,
-                adapter_name=adapter_name,
-                text=text,
-                png_file=png_file,
-                pdf_file=pdf_file,
-                pdf_url=pdf_url,
-            )
-            return
-        if send_pdf_tail:
-            await self._send_merge_pdf_tail_for_event(
-                event=event,
-                adapter_name=adapter_name,
-                pdf_file=pdf_file,
-                pdf_url=pdf_url,
-            )
-
-    async def _send_session_with_fallback(
-        self,
-        *,
-        context: Any,
-        session: str,
-        adapter_name: str,
-        merge_chain: MessageEventResult,
-        text: str,
-        png_file: Path,
-        pdf_file: Path,
-        pdf_url: str,
-        send_pdf_tail: bool,
-    ) -> bool:
-        try:
-            merge_ok = await context.send_message(session, merge_chain)
-            if not merge_ok:
-                logger.warning("合并转发发送返回失败，回退普通消息：会话=%s", session)
-                return await self._send_standard_session_push(
-                    context=context,
-                    session=session,
-                    adapter_name=adapter_name,
-                    text=text,
-                    png_file=png_file,
-                    pdf_file=pdf_file,
-                    pdf_url=pdf_url,
-                )
-        except Exception:
-            logger.warning("合并转发发送异常，回退普通消息：会话=%s", session, exc_info=True)
-            return await self._send_standard_session_push(
-                context=context,
-                session=session,
-                adapter_name=adapter_name,
-                text=text,
-                png_file=png_file,
-                pdf_file=pdf_file,
-                pdf_url=pdf_url,
-            )
-        if not send_pdf_tail:
-            return True
-        await self._send_merge_pdf_tail_for_session(
-            context=context,
-            session=session,
-            adapter_name=adapter_name,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
-        )
-        return True
-
-    async def _send_merge_pdf_tail_for_event(
-        self,
-        *,
-        event: AstrMessageEvent,
-        adapter_name: str,
-        pdf_file: Path,
-        pdf_url: str,
-    ) -> bool:
-        file_chain = self._build_pdf_only_chain(
-            adapter_name=adapter_name,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
-        )
-        if file_chain is None:
-            return True
-        try:
-            await event.send(file_chain)
-            return True
-        except Exception:
-            logger.warning("合并转发尾部 PDF 发送异常，但主体消息已发送成功。", exc_info=True)
-            return False
-
-    async def _send_merge_pdf_tail_for_session(
-        self,
-        *,
-        context: Any,
-        session: str,
-        adapter_name: str,
-        pdf_file: Path,
-        pdf_url: str,
-    ) -> bool:
-        file_chain = self._build_pdf_only_chain(
-            adapter_name=adapter_name,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
-        )
-        if file_chain is None:
-            return True
-        try:
-            tail_ok = await context.send_message(session, file_chain)
-        except Exception:
-            logger.warning("合并转发尾部 PDF 发送异常，但主体消息已发送成功：会话=%s", session, exc_info=True)
-            return False
-        if not tail_ok:
-            logger.warning("合并转发尾部 PDF 发送失败，但主体消息已发送成功：会话=%s", session)
-            return False
-        return True
-
-    async def _send_standard_event_push(
-        self,
-        *,
-        event: AstrMessageEvent,
-        adapter_name: str,
-        text: str,
-        png_file: Path,
-        pdf_file: Path,
-        pdf_url: str,
-    ) -> None:
-        for chain in self._build_standard_chains(
-            adapter_name=adapter_name,
-            text=text,
-            png_file=png_file,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
-        ):
-            await event.send(chain)
-
-    async def _send_standard_session_push(
-        self,
-        *,
-        context: Any,
-        session: str,
-        adapter_name: str,
-        text: str,
-        png_file: Path,
-        pdf_file: Path,
-        pdf_url: str,
-    ) -> bool:
-        sent_ok = True
-        for chain in self._build_standard_chains(
-            adapter_name=adapter_name,
-            text=text,
-            png_file=png_file,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
-        ):
-            if not await context.send_message(session, chain):
-                sent_ok = False
-        return sent_ok
-
-    def _build_standard_chains(
-        self,
-        *,
-        adapter_name: str,
-        text: str,
-        png_file: Path,
-        pdf_file: Path,
-        pdf_url: str,
-    ) -> list[MessageEventResult]:
-        if self._should_split_standard_file_send(adapter_name):
-            chains = [self._build_text_image_chain(text, png_file)]
-            file_chain = self._build_pdf_only_chain(
-                adapter_name=adapter_name,
-                pdf_file=pdf_file,
-                pdf_url=pdf_url,
-            )
-            if file_chain is not None:
-                chains.append(file_chain)
-            return chains
-        return [
-            self.build_standard_chain(
-                adapter_name=adapter_name,
-                text=text,
-                png_file=png_file,
-                pdf_file=pdf_file,
-                pdf_url=pdf_url,
-            ),
-        ]
-
-    def _build_text_image_chain(self, text: str, png_file: Path) -> MessageEventResult:
-        chain = MessageEventResult()
-        chain.chain.extend([
-            Plain(text),
-            Image.fromFileSystem(str(png_file)),
-        ])
-        return chain
-
-    def _build_pdf_only_chain(
-        self,
-        adapter_name: str,
-        pdf_file: Path,
-        pdf_url: str,
-    ) -> MessageEventResult | None:
-        file_component = self._build_pdf_component(
-            adapter_name=adapter_name,
-            pdf_file=pdf_file,
-            pdf_url=pdf_url,
-        )
-        if file_component is None:
-            return None
-        chain = MessageEventResult()
-        chain.chain.append(file_component)
-        return chain
-
-    def _should_split_standard_file_send(self, adapter_name: str) -> bool:
-        return adapter_name == ONEBOT_ADAPTER_NAME and self._cfg_bool("send_pdf", False)
-
-    async def _get_platform_self_id(self, platform: Any) -> str:
-        platform_meta = platform.meta()
-        platform_id = str(getattr(platform_meta, "id", "")).strip()
-        cached_self_id = self._self_id_cache.get(platform_id, "")
-        if cached_self_id:
-            return cached_self_id
-
-        bot = getattr(platform, "bot", None)
-        call_action = getattr(bot, "call_action", None)
-        if not callable(call_action):
-            return ""
-
-        try:
-            login_info = await call_action("get_login_info")
-        except Exception:
-            logger.warning("获取 OneBot 登录信息失败：平台=%s", platform_id, exc_info=True)
-            return ""
-
-        user_id = self._extract_user_id(login_info)
-        if user_id:
-            self._self_id_cache[platform_id] = user_id
-        return user_id
-
-    def _extract_user_id(self, login_info: Any) -> str:
-        if not isinstance(login_info, dict):
-            return ""
-
-        direct_user_id = str(login_info.get("user_id", "")).strip()
-        if direct_user_id:
-            return direct_user_id
-
-        data = login_info.get("data")
-        if not isinstance(data, dict):
-            return ""
-        return str(data.get("user_id", "")).strip()

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .models import RunReport
+
+DETAIL_URL_BASE = "https://shitjournal.org"
+
+
+class ReportRenderer:
+    def __init__(
+        self,
+        *,
+        status_labels: dict[str, str],
+        reason_labels: dict[str, str],
+        mask_sensitive_text: Callable[[str], str],
+        detail_url_base: str = DETAIL_URL_BASE,
+        detail_hide_domain: Callable[[], bool] | None = None,
+    ):
+        self._status_labels = dict(status_labels)
+        self._reason_labels = dict(reason_labels)
+        self._mask_sensitive_text = mask_sensitive_text
+        self._detail_url_base = str(detail_url_base).strip() or DETAIL_URL_BASE
+        self._detail_hide_domain = detail_hide_domain or (lambda: False)
+
+    def render_report(self, report: RunReport | dict[str, Any], include_debug: bool = False) -> str:
+        report_dict = self._to_run_report_dict(report)
+        status = str(report_dict.get("status", "unknown") or "unknown")
+        reason_code = str(report_dict.get("reason_code") or report_dict.get("reason") or "UNKNOWN")
+        debug_reason = self._mask_sensitive_text(str(report_dict.get("debug_reason", "")).strip())
+        latest_only = self._to_bool(report_dict.get("latest_only"), False)
+        requested_zone = str(report_dict.get("requested_zone", "")).strip()
+        warnings = self._clean_warning_list(report_dict.get("warnings", []))
+        status_text = self._render_status_text(status)
+        reason_text = self._render_reason_text(reason_code)
+        batches = list(report_dict.get("batches", []))
+        if len(batches) > 1:
+            return self._render_multi_batch_report(
+                report=report_dict,
+                status_text=status_text,
+                reason_text=reason_text,
+                latest_only=latest_only,
+                requested_zone=requested_zone,
+                warnings=warnings,
+                debug_reason=debug_reason,
+                include_debug=include_debug,
+            )
+        if len(batches) == 1:
+            return self._render_single_batch_report(
+                report=report_dict,
+                batch=batches[0],
+                status_text=status_text,
+                reason_text=reason_text,
+                latest_only=latest_only,
+                requested_zone=requested_zone,
+                warnings=warnings,
+                debug_reason=debug_reason,
+                include_debug=include_debug,
+            )
+        return self._render_single_batch_report(
+            report=report_dict,
+            batch=self._build_empty_batch(report_dict),
+            status_text=status_text,
+            reason_text=reason_text,
+            latest_only=latest_only,
+            requested_zone=requested_zone,
+            warnings=warnings,
+            debug_reason=debug_reason,
+            include_debug=include_debug,
+        )
+
+    def _build_empty_batch(self, report: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "status": str(report.get("status", "unknown") or "unknown"),
+            "zone": str(report.get("zone", "")).strip(),
+            "paper_id": str(report.get("paper_id", "")).strip(),
+            "detail_url": str(report.get("detail_url", "")).strip(),
+            "sent_ok": report.get("sent_ok", 0),
+            "sent_total": report.get("sent_total", 0),
+        }
+
+    def _to_run_report_dict(self, report: RunReport | dict[str, Any]) -> dict[str, Any]:
+        if isinstance(report, RunReport):
+            return report.to_dict()
+        return dict(report)
+
+    def _to_bool(self, value: Any, default: bool = False) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return default
+        if isinstance(value, (int, float)):
+            return bool(value)
+
+        text = str(value).strip().lower()
+        if not text:
+            return default
+        if text in {"1", "true", "t", "yes", "y", "on"}:
+            return True
+        if text in {"0", "false", "f", "no", "n", "off"}:
+            return False
+        return default
+
+    def _render_status_text(self, status: str) -> str:
+        return self._status_labels.get(status, status)
+
+    def _render_reason_text(self, reason_code: str) -> str:
+        return self._reason_labels.get(reason_code, reason_code)
+
+    def _clean_warning_list(self, raw: Any) -> list[str]:
+        if not isinstance(raw, list):
+            return []
+        warnings: list[str] = []
+        seen: set[str] = set()
+        for item in raw:
+            text = self._mask_sensitive_text(str(item).strip())
+            if not text or text in seen:
+                continue
+            seen.add(text)
+            warnings.append(text)
+        return warnings
+
+    def _append_warning_lines(self, lines: list[str], warnings: list[str]) -> None:
+        for index, warning in enumerate(self._clean_warning_list(warnings), start=1):
+            lines.append(f"告警{index}: {warning}")
+
+    def _render_run_mode_text(self, latest_only: bool) -> str:
+        if latest_only:
+            return "模式: 仅检查最新一篇"
+        return ""
+
+    def _render_report_header(self, status_text: str, reason_text: str) -> list[str]:
+        return [
+            f"[shitjournal 执行结果] 状态: {status_text}",
+            f"原因: {reason_text}",
+        ]
+
+    def _render_report_batch_line(self, index: int, batch: dict[str, Any]) -> list[str]:
+        detail_text = self._format_detail_text(str(batch.get("detail_url", "")))
+        batch_status = str(batch.get("status", "unknown") or "unknown")
+        batch_status_text = self._render_status_text(batch_status)
+        batch_reason_code = str(batch.get("reason_code", "")).strip()
+        batch_reason_text = self._render_reason_text(batch_reason_code) if batch_reason_code else ""
+        suffix = f" 原因={batch_reason_text}" if batch_status == "failed" and batch_reason_text else ""
+        return [
+            (
+                f"第{index}批: 状态={batch_status_text} 分区={batch.get('zone', '')} "
+                f"论文ID={batch.get('paper_id', '')} "
+                f"推送={batch.get('sent_ok', 0)}/{batch.get('sent_total', 0)} "
+                f"详情={detail_text}{suffix}"
+            ),
+        ]
+
+    def _append_report_suffix(
+        self,
+        *,
+        lines: list[str],
+        latest_only: bool,
+        requested_zone: str,
+        report_zone: str,
+        warnings: list[str],
+        debug_reason: str,
+        include_debug: bool,
+    ) -> str:
+        mode_text = self._render_run_mode_text(latest_only)
+        if mode_text:
+            lines.append(mode_text)
+        if requested_zone and requested_zone != report_zone:
+            lines.append(f"请求分区: {requested_zone}")
+        self._append_warning_lines(lines, warnings)
+        if include_debug and debug_reason:
+            lines.append(f"调试信息: {debug_reason}")
+        return "\n".join(lines)
+
+    def _render_single_batch_report(
+        self,
+        *,
+        report: dict[str, Any],
+        batch: dict[str, Any],
+        status_text: str,
+        reason_text: str,
+        latest_only: bool,
+        requested_zone: str,
+        warnings: list[str],
+        debug_reason: str,
+        include_debug: bool,
+    ) -> str:
+        lines = self._render_report_header(status_text, reason_text)
+        batch_reason_code = str(batch.get("reason_code", "")).strip()
+        lines.extend(
+            [
+                f"批次状态: {self._render_status_text(str(batch.get('status', 'unknown') or 'unknown'))}",
+                f"分区: {batch.get('zone', '')}",
+                f"论文 ID: {batch.get('paper_id', '')}",
+                f"推送: {batch.get('sent_ok', 0)}/{batch.get('sent_total', 0)}",
+                f"详情: {self._format_detail_text(str(batch.get('detail_url', '')))}",
+            ]
+        )
+        if batch_reason_code and batch_reason_code != "PUSHED_SUCCESSFULLY":
+            lines.append(f"批次原因: {self._render_reason_text(batch_reason_code)}")
+        return self._append_report_suffix(
+            lines=lines,
+            latest_only=latest_only,
+            requested_zone=requested_zone,
+            report_zone=str(report.get("zone", "")).strip(),
+            warnings=warnings,
+            debug_reason=debug_reason,
+            include_debug=include_debug,
+        )
+
+    def _render_multi_batch_report(
+        self,
+        *,
+        report: dict[str, Any],
+        status_text: str,
+        reason_text: str,
+        latest_only: bool,
+        requested_zone: str,
+        warnings: list[str],
+        debug_reason: str,
+        include_debug: bool,
+    ) -> str:
+        batches = list(report.get("batches", []))
+        lines = self._render_report_header(status_text, reason_text)
+        lines.append(f"总批次: {len(batches)}")
+        lines.append(f"总推送: {report.get('sent_ok', 0)}/{report.get('sent_total', 0)}")
+        for index, batch in enumerate(batches, start=1):
+            lines.extend(self._render_report_batch_line(index, batch))
+        return self._append_report_suffix(
+            lines=lines,
+            latest_only=latest_only,
+            requested_zone=requested_zone,
+            report_zone=str(report.get("zone", "")).strip(),
+            warnings=warnings,
+            debug_reason=debug_reason,
+            include_debug=include_debug,
+        )
+
+    def _format_detail_text(self, detail_url: str) -> str:
+        detail_text = str(detail_url or "").strip()
+        if not detail_text:
+            return detail_text
+        if not self._detail_hide_domain():
+            return detail_text
+        if detail_text.startswith(self._detail_url_base):
+            path = detail_text[len(self._detail_url_base) :].strip()
+            return path if path.startswith("/") else f"/{path}"
+        return detail_text

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Callable
 
 from .models import RunReport
+from .warning_text import append_warning_lines, clean_warning_list
 
 DETAIL_URL_BASE = "https://shitjournal.org"
 
@@ -30,7 +31,7 @@ class ReportRenderer:
         debug_reason = self._mask_sensitive_text(str(report_dict.get("debug_reason", "")).strip())
         latest_only = self._to_bool(report_dict.get("latest_only"), False)
         requested_zone = str(report_dict.get("requested_zone", "")).strip()
-        warnings = self._clean_warning_list(report_dict.get("warnings", []))
+        warnings = clean_warning_list(report_dict.get("warnings", []), self._mask_sensitive_text)
         status_text = self._render_status_text(status)
         reason_text = self._render_reason_text(reason_code)
         batches = list(report_dict.get("batches", []))
@@ -107,23 +108,6 @@ class ReportRenderer:
     def _render_reason_text(self, reason_code: str) -> str:
         return self._reason_labels.get(reason_code, reason_code)
 
-    def _clean_warning_list(self, raw: Any) -> list[str]:
-        if not isinstance(raw, list):
-            return []
-        warnings: list[str] = []
-        seen: set[str] = set()
-        for item in raw:
-            text = self._mask_sensitive_text(str(item).strip())
-            if not text or text in seen:
-                continue
-            seen.add(text)
-            warnings.append(text)
-        return warnings
-
-    def _append_warning_lines(self, lines: list[str], warnings: list[str]) -> None:
-        for index, warning in enumerate(self._clean_warning_list(warnings), start=1):
-            lines.append(f"告警{index}: {warning}")
-
     def _render_run_mode_text(self, latest_only: bool) -> str:
         if latest_only:
             return "模式: 仅检查最新一篇"
@@ -167,7 +151,7 @@ class ReportRenderer:
             lines.append(mode_text)
         if requested_zone and requested_zone != report_zone:
             lines.append(f"请求分区: {requested_zone}")
-        self._append_warning_lines(lines, warnings)
+        append_warning_lines(lines, warnings, self._mask_sensitive_text)
         if include_debug and debug_reason:
             lines.append(f"调试信息: {debug_reason}")
         return "\n".join(lines)

--- a/services/run_batch_sender.py
+++ b/services/run_batch_sender.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+from .models import RunBatch, RunBatchReport, RunReason, RunStatus
+class RunBatchSender:
+    def __init__(
+        self,
+        *,
+        context_getter: Callable[[], Any],
+        cfg_int_getter: Callable[[str, int, int | None, int | None], int],
+        history_store: Any,
+        load_submission_payload: Callable[[dict[str, Any], str], Awaitable[dict[str, Any]]],
+        prepare_pdf_assets: Callable[[dict[str, Any], str], Awaitable[tuple[Path, Path, str]]],
+        build_push_text: Callable[[dict[str, Any], str, str], str],
+        build_meta_preview: Callable[[dict[str, Any]], dict[str, Any]],
+        send_session_push: Callable[..., Awaitable[bool]],
+        release_temp_files: Callable[[Path | None, Path | None], Awaitable[None]],
+        maybe_trim_temp_files: Callable[[], Awaitable[None]],
+        logger: Any,
+        mask_sensitive_text: Callable[[str], str],
+        max_send_concurrency: int,
+        max_batch_send_concurrency: int,
+    ):
+        self._context_getter = context_getter
+        self._cfg_int_getter = cfg_int_getter
+        self._history_store = history_store
+        self._load_submission_payload = load_submission_payload
+        self._prepare_pdf_assets = prepare_pdf_assets
+        self._build_push_text = build_push_text
+        self._build_meta_preview = build_meta_preview
+        self._send_session_push = send_session_push
+        self._release_temp_files = release_temp_files
+        self._maybe_trim_temp_files = maybe_trim_temp_files
+        self._logger = logger
+        self._mask_sensitive_text = mask_sensitive_text
+        self._max_send_concurrency = int(max_send_concurrency)
+        self._max_batch_send_concurrency = int(max_batch_send_concurrency)
+    async def send_run_batches(
+        self,
+        batches: list[RunBatch],
+        *,
+        send_semaphore: asyncio.Semaphore | None = None,
+    ) -> list[RunBatchReport | dict[str, Any]]:
+        if not batches:
+            return []
+        batch_semaphore = asyncio.Semaphore(self.resolve_batch_send_concurrency(len(batches)))
+        async def _send_one(batch: RunBatch) -> RunBatchReport:
+            async with batch_semaphore:
+                return await self.send_run_batch(batch, send_semaphore=send_semaphore)
+        return await asyncio.gather(*[_send_one(batch) for batch in batches])
+    async def send_run_batch(
+        self,
+        batch: RunBatch,
+        *,
+        send_semaphore: asyncio.Semaphore | None = None,
+    ) -> RunBatchReport:
+        return await self.send_run_batch_inner(batch=batch, send_semaphore=send_semaphore)
+    async def send_run_batch_inner(
+        self,
+        *,
+        batch: RunBatch,
+        send_semaphore: asyncio.Semaphore | None,
+    ) -> RunBatchReport:
+        zone = str(batch.zone)
+        latest = dict(batch.latest)
+        paper_id = str(batch.paper_id)
+        detail_url = str(batch.detail_url)
+        targets = list(batch.targets)
+        report = self.build_run_batch_report(zone=zone, paper_id=paper_id, detail_url=detail_url, sent_total=len(targets))
+        pdf_file: Path | None = None
+        png_file: Path | None = None
+        try:
+            _, pdf_file, png_file, pdf_url, text = await self.prepare_run_batch_delivery(
+                latest=latest,
+                paper_id=paper_id,
+                detail_url=detail_url,
+                zone=zone,
+            )
+            sent_ok, success_targets = await self.send_push_to_targets(
+                targets=targets,
+                text=text,
+                png_file=png_file,
+                pdf_file=pdf_file,
+                pdf_url=pdf_url,
+                send_semaphore=send_semaphore,
+            )
+            report.sent_ok = sent_ok
+            await self.persist_run_batch_success_targets(
+                zone=zone,
+                paper_id=paper_id,
+                success_targets=success_targets,
+            )
+            report.status = self.resolve_send_status(sent_ok=sent_ok, sent_total=len(targets))
+            report.reason_code = self.resolve_send_reason_code(report.status)
+            return report
+        except Exception as exc:
+            return self.build_run_batch_exception_report(report=report, zone=zone, paper_id=paper_id, error=exc)
+        finally:
+            await self._release_temp_files(pdf_file, png_file)
+            try:
+                await self._maybe_trim_temp_files()
+            except Exception:
+                self._logger.warning("批次推送后清理临时文件失败。", exc_info=True)
+    async def prepare_run_batch_delivery(
+        self,
+        *,
+        latest: dict[str, Any],
+        paper_id: str,
+        detail_url: str,
+        zone: str,
+    ) -> tuple[dict[str, Any], Path | None, Path | None, str, str]:
+        payload = await self._load_submission_payload(latest, paper_id)
+        self._logger.info("论文元数据：%s", json.dumps(self._build_meta_preview(payload), ensure_ascii=False))
+        pdf_file, png_file, pdf_url = await self._prepare_pdf_assets(payload, paper_id)
+        text = self._build_push_text(payload, detail_url, zone)
+        return payload, pdf_file, png_file, pdf_url, text
+    async def send_push_to_targets(
+        self,
+        *,
+        targets: list[str],
+        text: str,
+        png_file: Path,
+        pdf_file: Path,
+        pdf_url: str,
+        send_semaphore: asyncio.Semaphore | None = None,
+    ) -> tuple[int, list[str]]:
+        semaphore = send_semaphore or asyncio.Semaphore(self.get_configured_send_concurrency())
+        async def _send_one(session: str) -> tuple[str, bool]:
+            async with semaphore:
+                try:
+                    ok = await self._send_session_push(
+                        context=self._context_getter(),
+                        session=session,
+                        text=text,
+                        png_file=png_file,
+                        pdf_file=pdf_file,
+                        pdf_url=pdf_url,
+                    )
+                except Exception:
+                    self._logger.error("发送消息失败：会话=%s", session, exc_info=True)
+                    ok = False
+            self._logger.info("发送消息结果：会话=%s 是否成功=%s", session, ok)
+            return session, ok
+        results = await asyncio.gather(*[_send_one(session) for session in targets], return_exceptions=True)
+        pairs = [item for item in results if not isinstance(item, BaseException)]
+        for item in results:
+            if isinstance(item, BaseException):
+                self._logger.error("发送任务出现未预期异常", exc_info=(type(item), item, item.__traceback__))
+        success_targets = [session for session, ok in pairs if ok]
+        return len(success_targets), success_targets
+    async def persist_run_batch_success_targets(
+        self,
+        *,
+        zone: str,
+        paper_id: str,
+        success_targets: list[str],
+    ) -> None:
+        if success_targets:
+            await self._history_store.mark_run_targets_delivered(
+                zone=zone,
+                paper_id=paper_id,
+                success_targets=success_targets,
+            )
+    def build_run_batch_exception_report(
+        self,
+        *,
+        report: RunBatchReport,
+        zone: str,
+        paper_id: str,
+        error: Exception,
+    ) -> RunBatchReport:
+        if report.sent_ok > 0:
+            self._logger.error(
+                "写入推送去重状态失败：分区=%s 论文ID=%s 错误=%s",
+                zone,
+                paper_id,
+                self._mask_sensitive_text(str(error)),
+                exc_info=True,
+            )
+            return self.build_failed_run_batch_report(
+                report=report,
+                reason_code=RunReason.DELIVERY_STATE_WRITE_FAILED,
+                debug_reason=str(error),
+            )
+        self._logger.error(
+            "批次推送失败：分区=%s 论文ID=%s 错误=%s",
+            zone,
+            paper_id,
+            self._mask_sensitive_text(str(error)),
+            exc_info=True,
+        )
+        return self.build_failed_run_batch_report(
+            report=report,
+            reason_code=RunReason.ALL_SENDS_FAILED,
+            debug_reason=str(error),
+        )
+    def build_run_batch_report(
+        self,
+        *,
+        zone: str,
+        paper_id: str,
+        detail_url: str,
+        sent_total: int,
+    ) -> RunBatchReport:
+        return RunBatchReport(
+            status=RunStatus.FAILED,
+            reason_code=RunReason.UNKNOWN,
+            zone=zone,
+            paper_id=paper_id,
+            detail_url=detail_url,
+            sent_ok=0,
+            sent_total=sent_total,
+            debug_reason="",
+        )
+    def build_failed_run_batch_report(
+        self,
+        *,
+        report: RunBatchReport,
+        reason_code: RunReason | str,
+        debug_reason: str,
+    ) -> RunBatchReport:
+        report.status = RunStatus.FAILED
+        report.reason_code = self.coerce_run_reason(reason_code)
+        report.debug_reason = self._mask_sensitive_text(debug_reason)
+        return report
+    def resolve_send_status(self, *, sent_ok: int, sent_total: int) -> RunStatus:
+        if sent_total > 0 and sent_ok == sent_total:
+            return RunStatus.SUCCESS
+        if sent_ok > 0:
+            return RunStatus.PARTIAL
+        return RunStatus.FAILED
+    def resolve_send_reason_code(self, status: RunStatus | str) -> RunReason:
+        normalized = self.coerce_run_status(status)
+        if normalized == RunStatus.SUCCESS:
+            return RunReason.PUSHED_SUCCESSFULLY
+        if normalized == RunStatus.PARTIAL:
+            return RunReason.PUSHED_PARTIALLY
+        return RunReason.ALL_SENDS_FAILED
+    def resolve_run_batch_reports(
+        self,
+        *,
+        batch_reports: list[RunBatchReport],
+        sent_ok: int,
+        sent_total: int,
+    ) -> tuple[RunStatus, RunReason]:
+        if any(batch.reason_code == RunReason.DELIVERY_STATE_WRITE_FAILED for batch in batch_reports):
+            return RunStatus.FAILED, RunReason.DELIVERY_STATE_WRITE_FAILED
+        status = self.resolve_send_status(sent_ok=sent_ok, sent_total=sent_total)
+        return status, self.resolve_send_reason_code(status)
+    def resolve_batch_send_concurrency(self, batch_count: int) -> int:
+        return min(self._max_batch_send_concurrency, self.get_configured_send_concurrency(), batch_count)
+    def get_configured_send_concurrency(self) -> int:
+        configured = self._cfg_int_getter(
+            "send_concurrency",
+            3,
+            min_value=1,
+            max_value=self._max_send_concurrency,
+        )
+        return min(self._max_send_concurrency, max(1, int(configured)))
+    def coerce_run_status(self, value: RunStatus | str) -> RunStatus:
+        if isinstance(value, RunStatus):
+            return value
+        try:
+            return RunStatus(str(value).strip().lower())
+        except ValueError:
+            return RunStatus.UNKNOWN
+    def coerce_run_reason(self, value: RunReason | str) -> RunReason:
+        if isinstance(value, RunReason):
+            return value
+        try:
+            return RunReason(str(value).strip())
+        except ValueError:
+            return RunReason.UNKNOWN
+    def coerce_run_batch_report(self, value: RunBatchReport | dict[str, Any]) -> RunBatchReport:
+        if isinstance(value, RunBatchReport):
+            return value
+        return RunBatchReport.from_dict(value)

--- a/services/run_cycle_service.py
+++ b/services/run_cycle_service.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable
+
+from .models import RunBatch, RunBatchReport, RunReason, RunReport, RunStatus
+from .run_selector import RunSelectionError, RunSelectionResult
+from .warning_text import join_warning_text
+
+
+class RunCycleService:
+    def __init__(
+        self,
+        *,
+        cfg_getter: Callable[[str, Any], Any],
+        run_selector: Any,
+        history_store: Any,
+        send_batches: Callable[..., Awaitable[list[RunBatchReport | dict[str, Any]]]],
+        coerce_run_batch_report: Callable[[RunBatchReport | dict[str, Any]], RunBatchReport],
+        resolve_run_batch_reports: Callable[[list[RunBatchReport], int, int], tuple[RunStatus, RunReason]],
+        get_primary_zone: Callable[[], str],
+        get_candidate_zones: Callable[[str], list[str]],
+        get_configured_send_concurrency: Callable[[], int],
+        maybe_trim_temp_files: Callable[[], Awaitable[None]],
+        logger: Any,
+        mask_sensitive_text: Callable[[str], str],
+        run_fetch_page_size: int,
+    ):
+        self._cfg_getter = cfg_getter
+        self._run_selector = run_selector
+        self._history_store = history_store
+        self._send_batches = send_batches
+        self._coerce_run_batch_report = coerce_run_batch_report
+        self._resolve_run_batch_reports = resolve_run_batch_reports
+        self._get_primary_zone = get_primary_zone
+        self._get_candidate_zones = get_candidate_zones
+        self._get_configured_send_concurrency = get_configured_send_concurrency
+        self._maybe_trim_temp_files = maybe_trim_temp_files
+        self._logger = logger
+        self._mask_sensitive_text = mask_sensitive_text
+        self._run_fetch_page_size = int(run_fetch_page_size)
+        self._run_lock = asyncio.Lock()
+
+    async def run_cycle(self, *, force: bool, source: str, latest_only: bool = False) -> RunReport:
+        if self._run_lock.locked():
+            return self._build_run_in_progress_report(source=source, latest_only=latest_only)
+        async with self._run_lock:
+            return await self._run_cycle_locked(force=force, source=source, latest_only=latest_only)
+
+    async def _run_cycle_locked(self, *, force: bool, source: str, latest_only: bool) -> RunReport:
+        primary_zone = self._get_primary_zone()
+        zone_order = self._get_candidate_zones(primary_zone)
+        report = self._build_run_cycle_report(
+            source=source,
+            primary_zone=primary_zone,
+            force=force,
+            latest_only=latest_only,
+        )
+        self._logger.info(
+            "开始执行推送：来源=%s 主分区=%s 分区顺序=%s 强制=%s 仅最新=%s",
+            source,
+            primary_zone,
+            zone_order,
+            force,
+            latest_only,
+        )
+        try:
+            targets = await self._history_store.get_all_target_sessions(self._cfg_getter("target_sessions", []))
+            if not targets:
+                report.reason_code = RunReason.NO_TARGET_SESSION_CONFIGURED
+                return report
+            previous_last_seen, selection = await self._select_run_cycle_batches(
+                report=report,
+                zone_order=zone_order,
+                targets=targets,
+                force=force,
+                latest_only=latest_only,
+            )
+            if selection is None:
+                return report
+            return await self._apply_selection(report, primary_zone, previous_last_seen, selection)
+        finally:
+            await self._trim_temp_files_after_run()
+
+    async def _apply_selection(
+        self,
+        report: RunReport,
+        primary_zone: str,
+        previous_last_seen: dict[str, str],
+        selection: RunSelectionResult,
+    ) -> RunReport:
+        if not selection.batches:
+            return await self._finalize_empty_run_selection(
+                report=report,
+                selection=selection,
+                previous_last_seen=previous_last_seen,
+            )
+        batch_reports = await self._deliver_selected_run_batches(selection.batches)
+        self._apply_run_batch_reports_to_report(report, batch_reports, primary_zone)
+        await self._persist_last_seen_map_if_changed(previous_last_seen, selection.last_seen_map)
+        report.status, report.reason_code = self._resolve_run_batch_reports(
+            batch_reports,
+            report.sent_ok,
+            report.sent_total,
+        )
+        return report
+
+    async def _trim_temp_files_after_run(self) -> None:
+        try:
+            await self._maybe_trim_temp_files()
+        except Exception:
+            self._logger.warning("执行推送后清理临时文件失败。", exc_info=True)
+
+    def _build_run_in_progress_report(self, *, source: str, latest_only: bool) -> RunReport:
+        return RunReport(
+            status=RunStatus.SKIPPED,
+            reason_code=RunReason.RUN_IN_PROGRESS,
+            source=source,
+            debug_reason="",
+            latest_only=latest_only,
+        )
+
+    def _build_run_cycle_report(
+        self,
+        *,
+        source: str,
+        primary_zone: str,
+        force: bool,
+        latest_only: bool,
+    ) -> RunReport:
+        return RunReport(
+            status=RunStatus.FAILED,
+            source=source,
+            zone=primary_zone,
+            requested_zone=primary_zone,
+            force=force,
+            latest_only=latest_only,
+        )
+
+    async def _select_run_cycle_batches(
+        self,
+        *,
+        report: RunReport,
+        zone_order: list[str],
+        targets: list[str],
+        force: bool,
+        latest_only: bool,
+    ) -> tuple[dict[str, str], RunSelectionResult | None]:
+        previous_last_seen = await self._history_store.get_last_seen_map()
+        try:
+            selection = await self._run_selector.select_run_batches(
+                zone_order=zone_order,
+                targets=targets,
+                last_seen_map=previous_last_seen,
+                force=force,
+                latest_only=latest_only,
+                fetch_page_size=self._run_fetch_page_size,
+            )
+        except RunSelectionError as exc:
+            self._apply_run_selection_error(report, self._coerce_run_reason(exc.reason_code), str(exc).strip())
+            return previous_last_seen, None
+        except RuntimeError as exc:
+            self._apply_run_selection_error(report, RunReason.FETCH_LATEST_FAILED, str(exc).strip())
+            return previous_last_seen, None
+        report.warnings = selection.warnings
+        return previous_last_seen, selection
+
+    def _apply_run_selection_error(self, report: RunReport, reason_code: RunReason, message: str) -> None:
+        report.reason_code = reason_code
+        self._logger.error("获取最新论文失败：%s", self._mask_sensitive_text(message), exc_info=True)
+        report.debug_reason = self._mask_sensitive_text(message)
+
+    async def _finalize_empty_run_selection(
+        self,
+        *,
+        report: RunReport,
+        selection: RunSelectionResult,
+        previous_last_seen: dict[str, str],
+    ) -> RunReport:
+        if selection.warnings:
+            report.status = RunStatus.FAILED
+            report.reason_code = RunReason.FETCH_LATEST_FAILED
+            report.debug_reason = join_warning_text(selection.warnings, self._mask_sensitive_text)
+        else:
+            report.status = RunStatus.SKIPPED
+            report.reason_code = RunReason.ALREADY_DELIVERED if selection.saw_submission else RunReason.LATEST_NOT_FOUND
+        await self._persist_last_seen_map_if_changed(previous_last_seen, selection.last_seen_map)
+        return report
+
+    async def _deliver_selected_run_batches(self, batches: list[RunBatch]) -> list[RunBatchReport]:
+        raw_reports = await self._send_batches(
+            batches,
+            send_semaphore=asyncio.Semaphore(self._get_configured_send_concurrency()),
+        )
+        return [self._coerce_run_batch_report(item) for item in raw_reports]
+
+    def _apply_run_batch_reports_to_report(
+        self,
+        report: RunReport,
+        batch_reports: list[RunBatchReport],
+        primary_zone: str,
+    ) -> None:
+        report.batches = batch_reports
+        report.sent_ok = sum(batch.sent_ok for batch in batch_reports)
+        report.sent_total = sum(batch.sent_total for batch in batch_reports)
+        if batch_reports:
+            first = batch_reports[0]
+            report.zone = first.zone or primary_zone
+            report.paper_id = first.paper_id
+            report.detail_url = first.detail_url
+        report.debug_reason = self._pick_first_debug_reason(batch_reports)
+
+    def _pick_first_debug_reason(self, batch_reports: list[RunBatchReport]) -> str:
+        for batch in batch_reports:
+            reason = self._mask_sensitive_text(str(batch.debug_reason).strip())
+            if reason:
+                return reason
+        return ""
+
+    async def _persist_last_seen_map_if_changed(
+        self,
+        previous_last_seen: dict[str, str],
+        next_last_seen_map: dict[str, str],
+    ) -> None:
+        if previous_last_seen != next_last_seen_map:
+            await self._history_store.set_last_seen_map(next_last_seen_map)
+
+    def _coerce_run_reason(self, value: RunReason | str) -> RunReason:
+        if isinstance(value, RunReason):
+            return value
+        try:
+            return RunReason(str(value).strip())
+        except ValueError:
+            return RunReason.UNKNOWN

--- a/services/run_selector.py
+++ b/services/run_selector.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+import json
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+from .models import RunBatch
+from .sensitive import mask_sensitive_text
+
+DETAIL_URL_BASE = "https://shitjournal.org"
+META_PREVIEW_KEYS = (
+    "id", "manuscript_title", "author_name", "institution", "discipline", "viscosity",
+    "created_at", "avg_score", "rating_count", "weighted_score", "pdf_path", "zone",
+)
+
+@dataclass(slots=True)
+class ChiShiSelection:
+    zone: str
+    paper_id: str
+    candidate: dict[str, Any]
+
+@dataclass(slots=True)
+class RunSelectionResult:
+    batches: list[RunBatch] = field(default_factory=list)
+    saw_submission: bool = False
+    warnings: list[str] = field(default_factory=list)
+    last_seen_map: dict[str, str] = field(default_factory=dict)
+
+class RunSelectionError(RuntimeError):
+    def __init__(self, reason_code: str, message: str = ""):
+        super().__init__(message or reason_code)
+        self.reason_code = reason_code
+
+class RunSelector:
+    def __init__(self, *, fetch_latest_submissions: Callable[[str, int, int], Awaitable[list[dict[str, Any]]]], get_run_sent_histories: Callable[[str, list[str]], Awaitable[dict[str, list[str]]]], get_chi_shi_sent_history: Callable[[str, str], Awaitable[list[str]]], logger: Any, detail_url_base: str = DETAIL_URL_BASE):
+        self._fetch = fetch_latest_submissions
+        self._get_run_histories = get_run_sent_histories
+        self._get_chi_shi_history = get_chi_shi_sent_history
+        self._logger = logger
+        self._detail_url_base = str(detail_url_base).strip() or DETAIL_URL_BASE
+
+    async def select_chi_shi_candidate_from_zones(self, *, zone_order: list[str], session_key: str, fetch_page_size: int) -> tuple[ChiShiSelection | None, bool, list[str]]:
+        return await self._select_chi_shi_candidate_from_zones(zone_order, session_key, fetch_page_size)
+
+    async def select_run_batches(self, *, zone_order: list[str], targets: list[str], last_seen_map: dict[str, str], force: bool, latest_only: bool, fetch_page_size: int) -> RunSelectionResult:
+        next_last_seen_map = dict(last_seen_map)
+        batches, saw_submission, warnings = await self._select_run_batches(
+            zone_order,
+            targets,
+            next_last_seen_map,
+            force,
+            latest_only,
+            fetch_page_size,
+        )
+        return RunSelectionResult(
+            batches=batches,
+            saw_submission=saw_submission,
+            warnings=warnings,
+            last_seen_map=next_last_seen_map,
+        )
+
+    async def _select_chi_shi_candidate_from_zones(self, zone_order, session_key, fetch_page_size):
+        saw_candidates = False
+        warnings = []
+        for idx, zone in enumerate(zone_order):
+            selected, zone_saw, zone_warnings = await self._select_chi_shi_zone_candidate(zone=zone, is_primary=idx == 0, session_key=session_key, fetch_page_size=fetch_page_size)
+            saw_candidates = saw_candidates or zone_saw
+            warnings.extend(zone_warnings)
+            if selected is not None:
+                return selected, True, warnings
+        return None, saw_candidates, warnings
+
+    async def _select_chi_shi_zone_candidate(self, *, zone, is_primary, session_key, fetch_page_size):
+        sent_set = set(await self._get_chi_shi_history(zone, session_key))
+        warnings, saw_candidates, offset = [], False, 0
+        while True:
+            try:
+                candidates = await self._fetch(zone, fetch_page_size, offset)
+            except Exception as exc:
+                warnings.append(self._build_zone_fetch_warning_text(zone=zone, is_primary=is_primary, offset=offset, error=exc))
+                self._logger.warning("获取“我要赤石”分区候选论文失败，已继续回退下一个分区：分区=%s 偏移=%s", zone, offset, exc_info=(type(exc), exc, exc.__traceback__))
+                return None, saw_candidates, warnings
+            if not candidates:
+                return None, saw_candidates, warnings
+            saw_candidates = True
+            picked = self._pick_first_unsent_candidate(candidates, sent_set)
+            if picked is not None:
+                paper_id, candidate = picked
+                return ChiShiSelection(zone=zone, paper_id=paper_id, candidate=candidate), True, warnings
+            if len(candidates) < fetch_page_size:
+                return None, saw_candidates, warnings
+            offset += len(candidates)
+
+    async def _select_run_batches(self, zone_order, targets, last_seen_map, force, latest_only, fetch_page_size):
+        if latest_only:
+            return await self._select_latest_only_run_batches(zone_order, targets, last_seen_map, force, fetch_page_size)
+        batches, warnings = [], []
+        saw_submission = False
+        unresolved_targets = targets.copy()
+        for idx, zone in enumerate(zone_order):
+            if not unresolved_targets:
+                break
+            first_page, zone_warnings = await self._fetch_run_candidates_page(zone, idx == 0, 0, fetch_page_size)
+            warnings.extend(zone_warnings)
+            if first_page is None:
+                continue
+            zone_batches, matched, zone_saw, page_warnings = await self._select_zone_run_batches(zone=zone, is_primary=idx == 0, unresolved_targets=unresolved_targets, last_seen_map=last_seen_map, force=force, first_page_candidates=first_page, fetch_page_size=fetch_page_size)
+            warnings.extend(page_warnings)
+            batches.extend(zone_batches)
+            saw_submission = saw_submission or zone_saw
+            unresolved_targets = self._subtract_targets(unresolved_targets, matched)
+        return batches, saw_submission, warnings
+
+    async def _select_latest_only_run_batches(self, zone_order, targets, last_seen_map, force, fetch_page_size):
+        batches, warnings = [], []
+        saw_submission = False
+        unresolved_targets = targets.copy()
+        for idx, zone in enumerate(zone_order):
+            if not unresolved_targets:
+                break
+            first_page, zone_warnings = await self._fetch_run_candidates_page(zone, idx == 0, 0, fetch_page_size)
+            warnings.extend(zone_warnings)
+            if first_page is None:
+                continue
+            batch, matched, zone_saw = await self._select_latest_only_zone_batch(zone=zone, is_primary=idx == 0, unresolved_targets=unresolved_targets, last_seen_map=last_seen_map, force=force, first_page_candidates=first_page)
+            if batch is not None:
+                batches.append(batch)
+            saw_submission = saw_submission or zone_saw
+            unresolved_targets = self._subtract_targets(unresolved_targets, matched)
+        return batches, saw_submission, warnings
+
+    async def _select_zone_run_batches(self, *, zone, is_primary, unresolved_targets, last_seen_map, force, first_page_candidates, fetch_page_size):
+        if not first_page_candidates:
+            return [], set(), False, []
+        run_history_by_target = await self._get_run_histories(zone, unresolved_targets)
+        sent_lookup = self._build_history_lookup(run_history_by_target)
+        batches, matched, warnings = [], set(), []
+        saw_submission, zone_latest_recorded, offset = False, False, 0
+        while True:
+            candidates, page_warnings = await self._load_run_candidates_page(zone=zone, is_primary=is_primary, first_page_candidates=first_page_candidates, offset=offset, fetch_page_size=fetch_page_size)
+            warnings.extend(page_warnings)
+            if not candidates:
+                break
+            saw_submission = True
+            page_batches, skip_zone, zone_latest_recorded, page_targets = self._build_zone_run_page_batches(zone, candidates, offset, unresolved_targets, matched, sent_lookup, force, is_primary, zone_latest_recorded, last_seen_map)
+            batches.extend(page_batches)
+            matched.update(page_targets)
+            if skip_zone or len(candidates) < fetch_page_size or len(matched) == len(unresolved_targets):
+                break
+            offset += len(candidates)
+        return batches, matched, saw_submission, warnings
+
+    async def _select_latest_only_zone_batch(self, *, zone, is_primary, unresolved_targets, last_seen_map, force, first_page_candidates):
+        if not first_page_candidates:
+            return None, set(), False
+        candidate = first_page_candidates[0]
+        paper_id = self._extract_run_candidate_paper_id(zone, candidate, is_primary)
+        if paper_id is None:
+            return None, set(), True
+        last_seen_map[zone] = paper_id
+        run_history_by_target = await self._get_run_histories(zone, unresolved_targets)
+        sent_lookup = self._build_history_lookup(run_history_by_target)
+        matched = self._match_run_batch_targets(paper_id, unresolved_targets, set(), sent_lookup, force)
+        if not matched:
+            return None, set(), True
+        batch = self._build_run_batch(zone, candidate, paper_id, matched)
+        return batch, set(matched), True
+
+    async def _load_run_candidates_page(self, *, zone, is_primary, first_page_candidates, offset, fetch_page_size):
+        if offset == 0:
+            return first_page_candidates, []
+        return await self._fetch_run_candidates_page(zone, is_primary, offset, fetch_page_size)
+
+    def _build_zone_run_page_batches(self, zone, candidates, offset, unresolved, matched, lookup, force, is_primary, zone_latest_recorded, last_seen_map):
+        page_batches, page_targets, occupied = [], set(), set(matched)
+        for idx, candidate in enumerate(candidates):
+            paper_id, skip_zone = self._resolve_page_candidate_id(zone, candidate, offset, idx, is_primary)
+            if skip_zone:
+                return [], True, zone_latest_recorded, page_targets
+            if not paper_id:
+                continue
+            zone_latest_recorded = self._record_zone_latest(zone, paper_id, zone_latest_recorded, last_seen_map)
+            batch_targets = self._match_run_batch_targets(paper_id, unresolved, occupied, lookup, force)
+            if not batch_targets:
+                continue
+            page_batches.append(self._build_run_batch(zone, candidate, paper_id, batch_targets))
+            page_targets.update(batch_targets)
+            occupied.update(batch_targets)
+        return page_batches, False, zone_latest_recorded, page_targets
+
+    def _resolve_page_candidate_id(self, zone, candidate, offset, candidate_index, is_primary):
+        paper_id = str(candidate.get("id", "")).strip()
+        if paper_id:
+            return paper_id, False
+        if offset == 0 and candidate_index == 0:
+            paper_id = self._extract_run_candidate_paper_id(zone, candidate, is_primary)
+            return paper_id, paper_id is None
+        self._logger.warning("候选论文缺少 ID，已跳过：分区=%s 载荷=%s", zone, json.dumps(self._build_meta_preview(candidate), ensure_ascii=False))
+        return None, False
+
+    def _record_zone_latest(self, zone, paper_id, zone_latest_recorded, last_seen_map):
+        if zone_latest_recorded:
+            return True
+        self._logger.info("已获取最新论文：分区=%s 论文ID=%s 详情=%s", zone, paper_id, self._build_preprint_detail_url(paper_id))
+        last_seen_map[zone] = paper_id
+        return True
+
+    def _subtract_targets(self, targets, removed_targets):
+        return targets if not removed_targets else [target for target in targets if target not in removed_targets]
+
+    def _match_run_batch_targets(self, paper_id, unresolved_targets, matched_targets, sent_lookup, force):
+        pending = []
+        for session in unresolved_targets:
+            if session in matched_targets:
+                continue
+            if not force and paper_id in sent_lookup.get(session, set()):
+                continue
+            pending.append(session)
+        return pending
+
+    def _build_run_batch(self, zone, candidate, paper_id, targets):
+        return RunBatch(zone=zone, latest=candidate, paper_id=paper_id, detail_url=self._build_preprint_detail_url(paper_id), targets=targets)
+
+    async def _fetch_run_candidates_page(self, zone, is_primary, offset, fetch_page_size):
+        try:
+            return await self._fetch(zone, fetch_page_size, offset), []
+        except Exception as exc:
+            warning = self._build_zone_fetch_warning_text(zone=zone, is_primary=is_primary, offset=offset, error=exc)
+            self._log_run_candidate_fetch_warning(zone, is_primary, offset, exc)
+            return None, [warning]
+
+    def _log_run_candidate_fetch_warning(self, zone, is_primary, offset, error):
+        zone_type = "主分区" if is_primary else "候补分区"
+        if offset == 0:
+            self._logger.warning("获取%s最新论文失败，已继续回退后续分区：分区=%s", zone_type, zone, exc_info=(type(error), error, error.__traceback__))
+            return
+        self._logger.warning("获取%s候选页失败，已停止继续检查该分区并回退后续分区：分区=%s 偏移=%s", zone_type, zone, offset, exc_info=(type(error), error, error.__traceback__))
+
+    def _raise_run_candidate_id_error(self, zone, is_primary, candidate):
+        zone_type = "主分区最新论文" if is_primary else "候补分区最新论文"
+        meta_preview = json.dumps(self._build_meta_preview(candidate), ensure_ascii=False)
+        raise RunSelectionError("EMPTY_PAPER_ID", f"{zone_type}缺少 ID：分区={zone} 载荷={meta_preview}")
+
+    def _log_run_candidate_id_warning(self, zone, candidate):
+        self._logger.warning("候补分区最新论文缺少 ID，已跳过该分区：分区=%s 载荷=%s", zone, json.dumps(self._build_meta_preview(candidate), ensure_ascii=False))
+
+    def _extract_run_candidate_paper_id(self, zone, candidate, is_primary):
+        paper_id = str(candidate.get("id", "")).strip()
+        if paper_id:
+            return paper_id
+        if is_primary:
+            self._raise_run_candidate_id_error(zone, is_primary, candidate)
+        self._log_run_candidate_id_warning(zone, candidate)
+        return None
+
+    def _pick_first_unsent_candidate(self, candidates, sent_set):
+        for candidate in candidates:
+            paper_id = str(candidate.get("id", "")).strip()
+            if paper_id and paper_id not in sent_set:
+                return paper_id, candidate
+        return None
+
+    def _build_history_lookup(self, history_by_target):
+        return {session: set(history) for session, history in history_by_target.items()}
+
+    def _build_preprint_detail_url(self, paper_id):
+        return f"{self._detail_url_base}/preprints/{str(paper_id).strip()}"
+
+    def _build_zone_fetch_warning_text(self, *, zone, is_primary, offset, error):
+        zone_type = "主分区" if is_primary else "候补分区"
+        position = "首页" if offset == 0 else f"偏移={offset}"
+        error_text = mask_sensitive_text(str(error).strip()) or type(error).__name__
+        return f"{zone_type}抓取失败：分区={zone} {position} 错误={error_text}"
+
+    def _build_meta_preview(self, payload):
+        return {key: payload.get(key) for key in META_PREVIEW_KEYS}

--- a/services/supabase_client.py
+++ b/services/supabase_client.py
@@ -37,14 +37,12 @@ class SupabaseClient:
         async with self._client_lock:
             client = self._client
             self._client = None
-
-        if client is None:
-            return
-
-        try:
-            await client.aclose()
-        except Exception:
-            logger.warning("关闭 HTTP 客户端失败。", exc_info=True)
+            if client is None:
+                return
+            try:
+                await client.aclose()
+            except Exception:
+                logger.warning("关闭 HTTP 客户端失败。", exc_info=True)
 
     async def fetch_latest_submissions(
         self,
@@ -110,6 +108,8 @@ class SupabaseClient:
         signed_url = self._validate_signed_url(signed_url)
         safe_url = self._mask_url(signed_url)
         target_path.parent.mkdir(parents=True, exist_ok=True)
+        max_pdf_mb = self._cfg_int("pdf_max_size_mb", 50, min_value=1, max_value=512)
+        max_pdf_bytes = max_pdf_mb * 1024 * 1024
         timeout, retry, _ = self._http_request_options()
         client = await self._get_http_client()
         last_error: Exception | None = None
@@ -117,16 +117,26 @@ class SupabaseClient:
         content_type = ""
 
         for attempt in range(1, retry + 1):
+            should_retry_after_release = False
             try:
                 async with client.stream(
                     method="GET",
                     url=signed_url,
                     headers=self._build_download_headers(),
-                    follow_redirects=True,
+                    follow_redirects=False,
                     timeout=timeout,
                 ) as response:
                     status_code = response.status_code
                     content_type = str(response.headers.get("content-type", ""))
+                    if 300 <= status_code < 400:
+                        location = self._mask_url(str(response.headers.get("location", "")).strip())
+                        logger.warning(
+                            "PDF 下载出现重定向，已阻止：状态码=%s 地址=%s 跳转=%s",
+                            status_code,
+                            safe_url,
+                            location or "<缺失>",
+                        )
+                        raise _NonRetryableRequestError("下载 PDF 时发生未预期的重定向")
                     if status_code >= 500 and attempt < retry:
                         logger.warning(
                             "PDF 下载因状态码触发重试：状态码=%s 尝试=%s/%s 地址=%s",
@@ -135,9 +145,8 @@ class SupabaseClient:
                             retry,
                             safe_url,
                         )
-                        await self._backoff_sleep(attempt)
-                        continue
-                    if status_code >= 400:
+                        should_retry_after_release = True
+                    elif status_code >= 400:
                         body_preview = await self._read_response_preview(response)
                         logger.warning(
                             "PDF 下载 HTTP 错误：状态码=%s 地址=%s 响应=%s",
@@ -154,21 +163,31 @@ class SupabaseClient:
                             content_type,
                         )
 
-                    header_preview = bytearray()
-                    async with aiofiles.open(target_path, "wb") as fp:
-                        async for chunk in response.aiter_bytes(chunk_size=1024 * 64):
-                            if not chunk:
-                                continue
-                            if len(header_preview) < 5:
-                                missing = 5 - len(header_preview)
-                                header_preview.extend(chunk[:missing])
-                                if len(header_preview) >= 5 and bytes(header_preview[:5]) != b"%PDF-":
+                    if not should_retry_after_release:
+                        header_preview = bytearray()
+                        downloaded_bytes = 0
+                        async with aiofiles.open(target_path, "wb") as fp:
+                            async for chunk in response.aiter_bytes(chunk_size=1024 * 64):
+                                if not chunk:
+                                    continue
+                                downloaded_bytes += len(chunk)
+                                if downloaded_bytes > max_pdf_bytes:
                                     raise _NonRetryableRequestError(
-                                        "下载的文件不是有效的 PDF",
+                                        f"PDF 文件过大：{downloaded_bytes} 字节，超过配置上限 {max_pdf_bytes} 字节",
                                     )
-                            await fp.write(chunk)
-                    if bytes(header_preview[:5]) != b"%PDF-":
-                        raise _NonRetryableRequestError("下载的文件不是有效的 PDF")
+                                if len(header_preview) < 5:
+                                    missing = 5 - len(header_preview)
+                                    header_preview.extend(chunk[:missing])
+                                    if len(header_preview) >= 5 and bytes(header_preview[:5]) != b"%PDF-":
+                                        raise _NonRetryableRequestError(
+                                            "下载的文件不是有效的 PDF",
+                                        )
+                                await fp.write(chunk)
+                        if bytes(header_preview[:5]) != b"%PDF-":
+                            raise _NonRetryableRequestError("下载的文件不是有效的 PDF")
+                if should_retry_after_release:
+                    await self._backoff_sleep(attempt)
+                    continue
                 break
             except Exception as exc:
                 last_error = exc
@@ -308,10 +327,6 @@ class SupabaseClient:
         await asyncio.sleep(delay)
 
     async def _get_http_client(self) -> httpx.AsyncClient:
-        client = self._client
-        if client is not None:
-            return client
-
         async with self._client_lock:
             client = self._client
             if client is not None:

--- a/services/supabase_client.py
+++ b/services/supabase_client.py
@@ -5,15 +5,28 @@ from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import quote, urlsplit
 
-import aiofiles
 import httpx
 from astrbot.api import logger
 
+from .http_executor import HttpExecutor, HttpRequestOptions
 from .sensitive import mask_sensitive_text
 
-
-class _NonRetryableRequestError(RuntimeError):
-    pass
+MAX_FETCH_LIMIT = 20
+MIN_FETCH_LIMIT = 1
+MIN_FETCH_OFFSET = 0
+SIGNED_URL_EXPIRES_SECONDS = 3600
+DEFAULT_PDF_MAX_SIZE_MB = 50
+MIN_PDF_MAX_SIZE_MB = 1
+MAX_PDF_MAX_SIZE_MB = 512
+BYTES_PER_MB = 1024 * 1024
+HTTP_TIMEOUT_DEFAULT_SEC = 20
+HTTP_TIMEOUT_MIN_SEC = 5
+HTTP_RETRY_DEFAULT = 3
+HTTP_RETRY_MIN = 1
+MAX_CONNECTIONS = 16
+MAX_KEEPALIVE_CONNECTIONS = 16
+BACKOFF_BASE_SECONDS = 2
+BACKOFF_MAX_SECONDS = 8
 
 
 class SupabaseClient:
@@ -32,6 +45,12 @@ class SupabaseClient:
         self._default_bucket = default_bucket
         self._client: httpx.AsyncClient | None = None
         self._client_lock = asyncio.Lock()
+        self._http_executor = HttpExecutor(
+            get_client=lambda: self._get_http_client(),
+            backoff_sleep=lambda attempt: self._backoff_sleep(attempt),
+            mask_text=mask_sensitive_text,
+            mask_url=lambda url: self._mask_url(url),
+        )
 
     async def close(self) -> None:
         async with self._client_lock:
@@ -50,8 +69,8 @@ class SupabaseClient:
         limit: int,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
-        safe_limit = max(1, min(int(limit), 20))
-        safe_offset = max(0, int(offset))
+        safe_limit = max(MIN_FETCH_LIMIT, min(int(limit), MAX_FETCH_LIMIT))
+        safe_offset = max(MIN_FETCH_OFFSET, int(offset))
         supabase_url = str(self._cfg("supabase_url", self._default_url)).strip()
         select_fields = (
             "id,manuscript_title,author_name,institution,viscosity,discipline,"
@@ -64,20 +83,13 @@ class SupabaseClient:
             "limit": str(safe_limit),
             "offset": str(safe_offset),
         }
-        if zone == "septic":
-            params["order"] = "promoted_to_septic_at.desc.nullslast"
-        else:
-            params["order"] = "created_at.desc"
+        params["order"] = "promoted_to_septic_at.desc.nullslast" if zone == "septic" else "created_at.desc"
 
         url = f"{supabase_url}/rest/v1/preprints_with_ratings_mat"
         data = await self._request_json("GET", url, params=params)
         if not isinstance(data, list) or not data:
             return []
-        result: list[dict[str, Any]] = []
-        for item in data:
-            if isinstance(item, dict):
-                result.append(item)
-        return result
+        return [item for item in data if isinstance(item, dict)]
 
     async def fetch_submission_detail(self, paper_id: str) -> dict[str, Any]:
         supabase_url = str(self._cfg("supabase_url", self._default_url)).strip()
@@ -97,7 +109,11 @@ class SupabaseClient:
         bucket = str(self._cfg("supabase_bucket", self._default_bucket)).strip()
         escaped = quote(pdf_path, safe="/")
         url = f"{supabase_url}/storage/v1/object/sign/{bucket}/{escaped}"
-        data = await self._request_json("POST", url, json_body={"expiresIn": 3600})
+        data = await self._request_json(
+            "POST",
+            url,
+            json_body={"expiresIn": SIGNED_URL_EXPIRES_SECONDS},
+        )
         signed = str((data or {}).get("signedURL", "")).strip()
         if not signed:
             logger.error("响应中缺少 signedURL 字段：地址=%s", self._mask_url(url))
@@ -105,133 +121,24 @@ class SupabaseClient:
         return self._resolve_signed_url(supabase_url, signed)
 
     async def download_pdf_file(self, signed_url: str, target_path: Path) -> tuple[int, str]:
-        signed_url = self._validate_signed_url(signed_url)
-        safe_url = self._mask_url(signed_url)
+        valid_signed_url = self._validate_signed_url(signed_url)
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        max_pdf_mb = self._cfg_int("pdf_max_size_mb", 50, min_value=1, max_value=512)
-        max_pdf_bytes = max_pdf_mb * 1024 * 1024
+        max_pdf_mb = self._cfg_int(
+            "pdf_max_size_mb",
+            DEFAULT_PDF_MAX_SIZE_MB,
+            min_value=MIN_PDF_MAX_SIZE_MB,
+            max_value=MAX_PDF_MAX_SIZE_MB,
+        )
+        max_pdf_bytes = max_pdf_mb * BYTES_PER_MB
         timeout, retry, _ = self._http_request_options()
-        client = await self._get_http_client()
-        last_error: Exception | None = None
-        status_code = 0
-        content_type = ""
-
-        for attempt in range(1, retry + 1):
-            should_retry_after_release = False
-            try:
-                async with client.stream(
-                    method="GET",
-                    url=signed_url,
-                    headers=self._build_download_headers(),
-                    follow_redirects=False,
-                    timeout=timeout,
-                ) as response:
-                    status_code = response.status_code
-                    content_type = str(response.headers.get("content-type", ""))
-                    if 300 <= status_code < 400:
-                        location = self._mask_url(str(response.headers.get("location", "")).strip())
-                        logger.warning(
-                            "PDF 下载出现重定向，已阻止：状态码=%s 地址=%s 跳转=%s",
-                            status_code,
-                            safe_url,
-                            location or "<缺失>",
-                        )
-                        raise _NonRetryableRequestError("下载 PDF 时发生未预期的重定向")
-                    if status_code >= 500 and attempt < retry:
-                        logger.warning(
-                            "PDF 下载因状态码触发重试：状态码=%s 尝试=%s/%s 地址=%s",
-                            status_code,
-                            attempt,
-                            retry,
-                            safe_url,
-                        )
-                        should_retry_after_release = True
-                    elif status_code >= 400:
-                        body_preview = await self._read_response_preview(response)
-                        logger.warning(
-                            "PDF 下载 HTTP 错误：状态码=%s 地址=%s 响应=%s",
-                            status_code,
-                            safe_url,
-                            body_preview,
-                        )
-                        raise _NonRetryableRequestError(
-                            f"下载 PDF 时出现 HTTP 错误：{status_code}",
-                        )
-                    if "application/pdf" not in content_type.lower():
-                        logger.warning(
-                            "PDF 响应的内容类型不是 application/pdf：%s（将继续校验文件头）",
-                            content_type,
-                        )
-
-                    if not should_retry_after_release:
-                        header_preview = bytearray()
-                        downloaded_bytes = 0
-                        async with aiofiles.open(target_path, "wb") as fp:
-                            async for chunk in response.aiter_bytes(chunk_size=1024 * 64):
-                                if not chunk:
-                                    continue
-                                downloaded_bytes += len(chunk)
-                                if downloaded_bytes > max_pdf_bytes:
-                                    raise _NonRetryableRequestError(
-                                        f"PDF 文件过大：{downloaded_bytes} 字节，超过配置上限 {max_pdf_bytes} 字节",
-                                    )
-                                if len(header_preview) < 5:
-                                    missing = 5 - len(header_preview)
-                                    header_preview.extend(chunk[:missing])
-                                    if len(header_preview) >= 5 and bytes(header_preview[:5]) != b"%PDF-":
-                                        raise _NonRetryableRequestError(
-                                            "下载的文件不是有效的 PDF",
-                                        )
-                                await fp.write(chunk)
-                        if bytes(header_preview[:5]) != b"%PDF-":
-                            raise _NonRetryableRequestError("下载的文件不是有效的 PDF")
-                if should_retry_after_release:
-                    await self._backoff_sleep(attempt)
-                    continue
-                break
-            except Exception as exc:
-                last_error = exc
-                self._remove_partial_file(target_path)
-                if isinstance(exc, _NonRetryableRequestError):
-                    break
-                if attempt < retry:
-                    logger.warning(
-                        "PDF 下载因异常触发重试：尝试=%s/%s 地址=%s 错误=%s",
-                        attempt,
-                        retry,
-                        safe_url,
-                        mask_sensitive_text(str(exc)),
-                    )
-                    await self._backoff_sleep(attempt)
-                    continue
-                break
-
-        if (not target_path.exists()) or target_path.stat().st_size <= 0:
-            if last_error is not None:
-                raise last_error
-            raise RuntimeError("下载后的 PDF 文件不存在")
-
-        return status_code, content_type
-
-    async def _read_response_preview(
-        self,
-        response: httpx.Response,
-        *,
-        max_bytes: int = 1024,
-        chunk_size: int = 256,
-        preview_chars: int = 300,
-    ) -> str:
-        preview = bytearray()
-        async for chunk in response.aiter_bytes(chunk_size=chunk_size):
-            if not chunk:
-                continue
-            remaining = max_bytes - len(preview)
-            if remaining <= 0:
-                break
-            preview.extend(chunk[:remaining])
-            if len(preview) >= max_bytes:
-                break
-        return self._decode_preview_bytes(preview, max_bytes=max_bytes, preview_chars=preview_chars)
+        options = HttpRequestOptions(timeout=timeout, retry=retry)
+        return await self._http_executor.download_pdf(
+            url=valid_signed_url,
+            target_path=target_path,
+            headers=self._build_download_headers(),
+            max_bytes=max_pdf_bytes,
+            options=options,
+        )
 
     async def _request_json(
         self,
@@ -240,90 +147,25 @@ class SupabaseClient:
         params: dict[str, Any] | None = None,
         json_body: dict[str, Any] | None = None,
     ) -> Any:
-        safe_url = self._mask_url(url)
         timeout, retry, headers = self._http_request_options()
-        client = await self._get_http_client()
-        last_error: Exception | None = None
-        for attempt in range(1, retry + 1):
-            try:
-                response = await client.request(
-                    method=method,
-                    url=url,
-                    params=params,
-                    json=json_body,
-                    headers=headers,
-                    follow_redirects=False,
-                    timeout=timeout,
-                )
-                if 300 <= response.status_code < 400:
-                    location = self._mask_url(str(response.headers.get("location", "")).strip())
-                    logger.warning(
-                        "Supabase 请求被重定向，已阻止：状态码=%s 地址=%s 跳转=%s",
-                        response.status_code,
-                        safe_url,
-                        location or "<缺失>",
-                    )
-                    raise _NonRetryableRequestError("Supabase 请求发生未预期的重定向")
-                if response.status_code >= 500 and attempt < retry:
-                    logger.warning(
-                        "HTTP 请求因状态码触发重试：状态码=%s 尝试=%s/%s 地址=%s",
-                        response.status_code,
-                        attempt,
-                        retry,
-                        safe_url,
-                    )
-                    await self._backoff_sleep(attempt)
-                    continue
-                if response.status_code >= 400:
-                    body_preview = self._decode_preview_bytes(response.content)
-                    logger.warning(
-                        "Supabase 请求 HTTP 错误：状态码=%s 地址=%s 响应=%s",
-                        response.status_code,
-                        safe_url,
-                        body_preview,
-                    )
-                    raise _NonRetryableRequestError(
-                        f"Supabase 请求返回 HTTP 错误：{response.status_code}",
-                    )
-                try:
-                    return response.json()
-                except Exception:
-                    body_preview = self._decode_preview_bytes(response.content)
-                    logger.warning(
-                        "Supabase 响应 JSON 解析失败：地址=%s 响应=%s",
-                        safe_url,
-                        body_preview,
-                    )
-                    raise _NonRetryableRequestError(
-                        "Supabase 响应 JSON 解析失败",
-                    )
-            except Exception as exc:
-                last_error = exc
-                if isinstance(exc, _NonRetryableRequestError):
-                    break
-                if attempt < retry:
-                    logger.warning(
-                        "HTTP 请求因异常触发重试：尝试=%s/%s 地址=%s 错误=%s",
-                        attempt,
-                        retry,
-                        safe_url,
-                        mask_sensitive_text(str(exc)),
-                    )
-                    await self._backoff_sleep(attempt)
-                    continue
-                break
-
-        assert last_error is not None
-        raise last_error
+        options = HttpRequestOptions(timeout=timeout, retry=retry)
+        return await self._http_executor.request_json(
+            method=method,
+            url=url,
+            params=params,
+            json_body=json_body,
+            headers=headers,
+            options=options,
+        )
 
     def _http_request_options(self) -> tuple[int, int, dict[str, str]]:
-        timeout = self._cfg_int("http_timeout_sec", 20, min_value=5)
-        retry = self._cfg_int("http_retry", 3, min_value=1)
+        timeout = self._cfg_int("http_timeout_sec", HTTP_TIMEOUT_DEFAULT_SEC, min_value=HTTP_TIMEOUT_MIN_SEC)
+        retry = self._cfg_int("http_retry", HTTP_RETRY_DEFAULT, min_value=HTTP_RETRY_MIN)
         headers = self._build_supabase_headers()
         return timeout, retry, headers
 
     async def _backoff_sleep(self, attempt: int) -> None:
-        delay = min(2 ** (attempt - 1), 8)
+        delay = min(BACKOFF_BASE_SECONDS ** (attempt - 1), BACKOFF_MAX_SECONDS)
         await asyncio.sleep(delay)
 
     async def _get_http_client(self) -> httpx.AsyncClient:
@@ -332,7 +174,10 @@ class SupabaseClient:
             if client is not None:
                 return client
 
-            limits = httpx.Limits(max_connections=16, max_keepalive_connections=16)
+            limits = httpx.Limits(
+                max_connections=MAX_CONNECTIONS,
+                max_keepalive_connections=MAX_KEEPALIVE_CONNECTIONS,
+            )
             self._client = httpx.AsyncClient(limits=limits, follow_redirects=False)
             return self._client
 
@@ -349,22 +194,6 @@ class SupabaseClient:
         return {
             "Accept": "application/pdf",
         }
-
-    def _decode_preview_bytes(
-        self,
-        data: bytes | bytearray,
-        *,
-        max_bytes: int = 1024,
-        preview_chars: int = 300,
-    ) -> str:
-        preview_bytes = bytes(data[:max_bytes])
-        return mask_sensitive_text(preview_bytes[:preview_chars].decode("utf-8", errors="replace"))
-
-    def _remove_partial_file(self, target_path: Path) -> None:
-        try:
-            target_path.unlink(missing_ok=True)
-        except Exception:
-            logger.warning("删除未完成的下载文件失败：%s", str(target_path), exc_info=True)
 
     def _resolve_signed_url(self, supabase_url: str, signed: str) -> str:
         parsed = urlsplit(signed)

--- a/services/warning_text.py
+++ b/services/warning_text.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def clean_warning_list(raw: Any, mask_sensitive_text: Callable[[str], str]) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    warnings: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        text = mask_sensitive_text(str(item).strip())
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        warnings.append(text)
+    return warnings
+
+
+def join_warning_text(warnings: list[str], mask_sensitive_text: Callable[[str], str]) -> str:
+    return "；".join(clean_warning_list(warnings, mask_sensitive_text))
+
+
+def append_warning_lines(
+    lines: list[str],
+    warnings: list[str],
+    mask_sensitive_text: Callable[[str], str],
+) -> None:
+    for index, warning in enumerate(
+        clean_warning_list(warnings, mask_sensitive_text),
+        start=1,
+    ):
+        lines.append(f"告警{index}: {warning}")


### PR DESCRIPTION
- 引入强类型运行模型，新增 `services/models.py`，收口运行状态、批次和报告数据
- 抽离历史存储与选稿逻辑到 `services/history_store.py`、`services/run_selector.py`
- 抽离资产准备与报告渲染到 `services/asset_pipeline.py`、`services/report_renderer.py`
- 重构消息发送链路，新增 `services/message_sink.py`、`services/push_chain_builder.py`，保留 `services/push_message_service.py` 作为门面
- 为 Supabase 请求统一执行器，新增 `services/http_executor.py`，收口重试、下载校验和响应处理逻辑
- 拆出命令入口和运行编排相关服务，包括 `services/command_gate.py`、`services/cron_scheduler.py`、`services/run_batch_sender.py`、`services/run_cycle_service.py`、`services/chi_shi_service.py`
- 精简 `main.py`，使其主要承担生命周期、命令入口、依赖装配和少量插件级辅助职责
- 修复 `ChiShiService` 在发送或历史写入异常时的临时资源释放路径